### PR TITLE
Validate req.body is array in PUT /backup-schedules

### DIFF
--- a/server/routes/v025-features.js
+++ b/server/routes/v025-features.js
@@ -205,13 +205,17 @@ router.get('/backup-schedules', (req, res) => {
 
 router.put('/backup-schedules', (req, res) => {
   try {
+    if (!Array.isArray(req.body)) {
+      return res.status(400).json({ error: 'Request body must be an array of schedules' });
+    }
     const db = getDb();
     db.prepare("INSERT OR REPLACE INTO config (key, value) VALUES ('backup_schedules', ?)").run(JSON.stringify(req.body));
-    auditLog(db, req.user?.id || 'system', 'BACKUP_SCHEDULES_UPDATED', `${req.body.length} schedules configured`);
     db.close();
+    auditLog(req.user?.id || 'system', 'BACKUP_SCHEDULES_UPDATED', `${req.body.length} schedules configured`, req.ip);
     res.json({ success: true });
   } catch (e) { res.status(500).json({ error: 'Failed to save backup schedules' }); }
 });
+
 
 // ── Sync Interval Configuration ─────────────────────────────────────────────
 router.get('/sync-interval/config', (req, res) => {


### PR DESCRIPTION
Closes CodeQL alert #12 (CWE-843). Reject non-array bodies with 400. Also fixes auditLog argument order (was passing db as first arg).