### PR TITLE
Normalize auditLog arguments to fix corrupted audit rows

### DIFF
--- a/server/middleware/audit.js
+++ b/server/middleware/audit.js
@@ -58,7 +58,19 @@ function auditMiddleware(req, res, next) {
 /**
  * Write an explicit audit entry (for business events, not just HTTP requests)
  */
-function auditLog(userId, eventType, detail, ip) {
+function auditLog(...args) {
+  // Backward-compat: many callers historically passed (db, userId, eventType, detail)
+  // as 4 args, or (userId, eventType, detail, ip) as 4 args. Detect and normalize.
+  let userId, eventType, detail, ip;
+  if (args.length >= 4 && args[0] && typeof args[0] === 'object' && typeof args[0].prepare === 'function') {
+    // Legacy shape: (db, userId, eventType, detail)
+    [, userId, eventType, detail] = args;
+    ip = null;
+  } else {
+    // Correct shape: (userId, eventType, detail, ip)
+    [userId, eventType, detail, ip] = args;
+  }
+
   try {
     const db = getDb();
     const cef = formatCEF(eventType, userId, detail, ip);
@@ -74,6 +86,7 @@ function auditLog(userId, eventType, detail, ip) {
     logger.error('Audit log write failed', { error: err.message });
   }
 }
+
 
 /**
  * Stream CEF message to SIEM via syslog


### PR DESCRIPTION
auditLog had two calling conventions in the codebase: (db, userId, eventType, detail) used by ~78 callers and (userId, eventType, detail, ip) matching the documented signature. The legacy shape was writing the db object's string representation into the user_id column, corrupting every audit row from those callers. This change detects the legacy shape (arg 0 is a db handle) and normalizes to the correct column mapping. Future PRs will migrate callers to the canonical signature and remove this shim.