### PR TITLE
Migrate auditLog callers in v100-features.js (issue #24, file 2 of 8)

### DIFF
--- a/server/routes/v100-features.js
+++ b/server/routes/v100-features.js
@@ -42,7 +42,7 @@ router.post('/assessments/create', requireAuth, requireRole('manager'), (req, re
   const svc = new AssessmentService(req.app.locals.db);
   const { category, platform, targetAnalyst } = req.body;
   const result = svc.create(category, platform, targetAnalyst, req.user.id);
-  auditLog(req.app.locals.db, req.user.id, 'ASSESSMENT_CREATED', `${category} → ${targetAnalyst}`);
+  auditLog(req.user.id, 'ASSESSMENT_CREATED', `${category} → ${targetAnalyst}`);
   // Send notification to analyst
   const { NotificationService } = require('../services/notification-service');
   new NotificationService(req.app.locals.db).send(targetAnalyst, 'assessment', 'New Assessment', `${category} assessment assigned`, 'skills');
@@ -51,7 +51,7 @@ router.post('/assessments/create', requireAuth, requireRole('manager'), (req, re
 router.post('/assessments/submit', requireAuth, (req, res) => {
   const { AssessmentService } = require('../services/assessment-service');
   const result = new AssessmentService(req.app.locals.db).submitResults(req.body.assessmentId, req.body.score);
-  auditLog(req.app.locals.db, req.user.id, 'ASSESSMENT_SUBMITTED', `Score: ${req.body.score}%`);
+  auditLog(req.user.id, 'ASSESSMENT_SUBMITTED', `Score: ${req.body.score}%`);
   res.json(result);
 });
 router.get('/assessments/analyst/:id', requireAuth, (req, res) => {
@@ -67,7 +67,7 @@ router.get('/skills/:analystId', requireAuth, (req, res) => {
 router.post('/backup/create', requireAuth, requireRole('manager'), (req, res) => {
   const { BackupService } = require('../services/backup-service');
   const result = new BackupService(req.app.locals.db).createBackup(req.body.type || 'full');
-  auditLog(req.app.locals.db, req.user.id, 'BACKUP_CREATED', `Type: ${req.body.type || 'full'}`);
+  auditLog(req.user.id, 'BACKUP_CREATED', `Type: ${req.body.type || 'full'}`);
   res.json(result);
 });
 router.get('/backup/history', requireAuth, (req, res) => {
@@ -78,7 +78,7 @@ router.post('/backup/schedule/add', requireAuth, requireRole('manager'), (req, r
   const { BackupService } = require('../services/backup-service');
   const { type, interval, retention, destination } = req.body;
   new BackupService(req.app.locals.db).addSchedule(type, interval, retention, destination);
-  auditLog(req.app.locals.db, req.user.id, 'BACKUP_SCHEDULE', `${type} every ${interval}`);
+  auditLog(req.user.id, 'BACKUP_SCHEDULE', `${type} every ${interval}`);
   res.json({ saved: true });
 });
 router.post('/backup/restore/:id', requireAuth, requireRole('manager'), (req, res) => {
@@ -91,7 +91,7 @@ router.post('/compliance/scan', requireAuth, requireRole('manager'), (req, res) 
   const { ComplianceScanner } = require('../services/compliance-scanner');
   if (!validate.framework(req.body.framework)) return res.status(400).json({ error: 'Invalid framework' });
   const result = new ComplianceScanner(req.app.locals.db).scan(req.body.framework);
-  auditLog(req.app.locals.db, req.user.id, 'COMPLIANCE_SCAN', `Framework: ${req.body.framework}`);
+  auditLog(req.user.id, 'COMPLIANCE_SCAN', `Framework: ${req.body.framework}`);
   res.json(result);
 });
 
@@ -99,7 +99,7 @@ router.post('/compliance/scan', requireAuth, requireRole('manager'), (req, res) 
 router.post('/regression/run', requireAuth, requireRole('manager'), (req, res) => {
   const { RegressionRunner } = require('../services/regression-runner');
   const result = new RegressionRunner(req.app.locals.db).run();
-  auditLog(req.app.locals.db, req.user.id, 'REGRESSION_RUN', `${result.passed}/${result.total} passed`);
+  auditLog(req.user.id, 'REGRESSION_RUN', `${result.passed}/${result.total} passed`);
   res.json(result);
 });
 
@@ -110,7 +110,7 @@ router.post('/integrations/save', requireAuth, requireRole('manager'), (req, res
   const { type, platform, endpoint, apiKey } = req.body;
   const hash = crypto.createHash('sha256').update(apiKey || '').digest('hex');
   const result = mgr.saveConfig(type, platform, endpoint, hash);
-  auditLog(req.app.locals.db, req.user.id, 'INTEGRATION_SAVED', `${type}: ${platform}`);
+  auditLog(req.user.id, 'INTEGRATION_SAVED', `${type}: ${platform}`);
   res.json(result);
 });
 router.post('/integrations/test', requireAuth, requireRole('manager'), async (req, res) => {
@@ -148,14 +148,14 @@ router.post('/notifications/:id/read', requireAuth, (req, res) => {
 router.post('/config/lock', requireAuth, requireRole('manager'), (req, res) => {
   const { locked } = req.body;
   req.app.locals.db.prepare("INSERT OR REPLACE INTO config (key, value) VALUES ('config_locked', ?)").run(locked ? 'true' : 'false');
-  auditLog(req.app.locals.db, req.user.id, 'CONFIG_LOCK', locked ? 'LOCKED' : 'UNLOCKED');
+  auditLog(req.user.id, 'CONFIG_LOCK', locked ? 'LOCKED' : 'UNLOCKED');
   res.json({ locked });
 });
 
 // SLA
 router.post('/sla/save', requireAuth, requireRole('manager'), (req, res) => {
   req.app.locals.db.prepare("INSERT OR REPLACE INTO config (key, value) VALUES ('sla_targets', ?)").run(JSON.stringify(req.body.targets));
-  auditLog(req.app.locals.db, req.user.id, 'SLA_UPDATED', 'SLA targets modified');
+  auditLog(req.user.id, 'SLA_UPDATED', 'SLA targets modified');
   res.json({ saved: true });
 });
 
@@ -166,7 +166,7 @@ router.post('/handoff/save', requireAuth, requireRole('manager'), (req, res) => 
   // Notify incoming lead
   notif.send('incoming_lead', 'handoff', 'Shift Handoff', req.body.notes || 'Handoff notes available', 'handoff');
   req.app.locals.db.prepare("INSERT INTO config (key, value) VALUES (?, ?)").run(`handoff_${Date.now()}`, JSON.stringify({ notes: req.body.notes, from: req.user.id, at: new Date().toISOString() }));
-  auditLog(req.app.locals.db, req.user.id, 'HANDOFF', 'Shift handoff saved + notification sent');
+  auditLog(req.user.id, 'HANDOFF', 'Shift handoff saved + notification sent');
   res.json({ saved: true, notified: true });
 });
 
@@ -175,7 +175,7 @@ router.post('/config/snapshot', requireAuth, requireRole('manager'), (req, res) 
   const allConfig = req.app.locals.db.prepare("SELECT * FROM config").all();
   const id = crypto.randomUUID();
   req.app.locals.db.prepare("INSERT INTO config (key, value) VALUES (?, ?)").run(`snapshot_${id}`, JSON.stringify({ configs: allConfig, createdAt: new Date().toISOString() }));
-  auditLog(req.app.locals.db, req.user.id, 'CONFIG_SNAPSHOT', `Snapshot ${id}`);
+  auditLog(req.user.id, 'CONFIG_SNAPSHOT', `Snapshot ${id}`);
   res.json({ id, created: true });
 });
 
@@ -188,7 +188,7 @@ router.post('/heartbeat', requireAuth, (req, res) => {
 // Audit log endpoint (used by all frontend buttons)
 router.post('/audit/log', requireAuth, (req, res) => {
   const { event, detail } = req.body;
-  auditLog(req.app.locals.db, req.user?.id || 'system', event || 'ACTION', detail || '');
+  auditLog(req.user?.id || 'system', event || 'ACTION', detail || '');
   res.json({ logged: true });
 });
 
@@ -197,7 +197,7 @@ router.post('/config/save', requireAuth, requireRole('manager'), (req, res) => {
   const { key, value } = req.body;
   if (!key) return res.status(400).json({ error: 'Key required' });
   req.app.locals.db.prepare('INSERT OR REPLACE INTO config (key, value) VALUES (?, ?)').run(key, JSON.stringify(value || ''));
-  auditLog(req.app.locals.db, req.user.id, 'CONFIG_SAVE', key);
+  auditLog(req.user.id, 'CONFIG_SAVE', key);
   res.json({ saved: true });
 });
 


### PR DESCRIPTION
Part of issue #24 — migration of auditLog callers from legacy `(db, userId, eventType, detail)` signature to canonical `(userId, eventType, detail, ip)` signature.

This PR migrates 13 calls in `server/routes/v100-features.js`. The shim in `server/middleware/audit.js` continues to handle any unmigrated callers in other files; it will be removed in the final PR of this series once all callers are migrated.

No behavior change expected — the shim previously normalized these calls to the same shape we're now passing explicitly.
