### PR TITLE
Remove auditLog backward-compat shim (issue #24, final PR)

### DIFF
--- a/server/middleware/audit.js
+++ b/server/middleware/audit.js
@@ -57,20 +57,13 @@ function auditMiddleware(req, res, next) {
 
 /**
  * Write an explicit audit entry (for business events, not just HTTP requests)
+ *
+ * @param {string} userId - User ID, pseudonym, or 'system'/'SYSTEM' for non-user events
+ * @param {string} eventType - Event type identifier (e.g. 'CONFIG_UPDATED', 'BACKUP_CREATED')
+ * @param {string} detail - Human-readable detail string
+ * @param {string} [ip] - Optional IP address; pass req.ip from route handlers
  */
-function auditLog(...args) {
-  // Backward-compat: many callers historically passed (db, userId, eventType, detail)
-  // as 4 args, or (userId, eventType, detail, ip) as 4 args. Detect and normalize.
-  let userId, eventType, detail, ip;
-  if (args.length >= 4 && args[0] && typeof args[0] === 'object' && typeof args[0].prepare === 'function') {
-    // Legacy shape: (db, userId, eventType, detail)
-    [, userId, eventType, detail] = args;
-    ip = null;
-  } else {
-    // Correct shape: (userId, eventType, detail, ip)
-    [userId, eventType, detail, ip] = args;
-  }
-
+function auditLog(userId, eventType, detail, ip) {
   try {
     const db = getDb();
     const cef = formatCEF(eventType, userId, detail, ip);


### PR DESCRIPTION
Final PR for issue #24. Removes the backward-compat shim from `server/middleware/audit.js` that was added in PR #[whichever PR 1 was] to handle legacy `(db, userId, eventType, detail)` callers while migration was in progress.

All 77 legacy callers have been migrated to the canonical `(userId, eventType, detail, ip)` signature across the following files:

- server/routes/v059-features.js (7 calls)
- server/routes/v100-features.js (13 calls)
- server/routes/v027-features.js (11 calls)
- server/routes/v030-features.js (10 calls)
- server/routes/v024-features.js (12 calls)
- server/routes/v025-features.js (9 calls)
- server/routes/v054-features.js (15 calls)

This PR also adds JSDoc documentation to the canonical signature so future contributors know the correct calling convention.

Closes #24.