### PR TITLE
Fix duplicate rateLimit import causing SyntaxError

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -7,7 +7,7 @@
 require('dotenv').config();
 
 const express = require('express');
-const { securityHeaders, sanitizeInput, rateLimit, antiReplay, maxBodySize, enforceMinTls } = require('./middleware/security-hardening');
+const { securityHeaders, sanitizeInput, antiReplay, maxBodySize, enforceMinTls } = require('./middleware/security-hardening');
 const { corsPolicy } = require('./middleware/cors-policy');
 const { detectSuspiciousInput } = require('./middleware/auth-hardening');
 const { aiSecurityMiddleware } = require('./middleware/ai-security');


### PR DESCRIPTION
`server/index.js` declared `rateLimit` twice in the same scope:
- Line 10: destructured from `./middleware/security-hardening`
- Line 18: imported as the `express-rate-limit` package

This produces `SyntaxError: Identifier 'rateLimit' has already been declared` and prevents the server from starting. The custom `rateLimit` exported by `security-hardening.js` was not used anywhere in `index.js` (only the express-rate-limit package version is wired into `app.use('/api/', apiLimiter)` on line 87). Removed the unused destructured import.

This unblocks the global rate limiter (1000 req/15min on `/api/*`), which is relevant to the wave of CodeQL `js/missing-rate-limiting` alerts about to be reviewed under issue #26.
