### PR TITLE
Phase 1.1 (1/2): Fix server/index.js boot path

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -189,11 +189,22 @@ async function start() {
       detectMissingLogs();
     }, 3600000);
 
-    const server = const server = app.listen(PORT, HOST, () => {
-      logger.info(`FireAlive v0.0.21 running on http://${HOST}:${PORT}`);
-      logger.info(`Fuse counter: ${process.env.FUSE_COUNTER || 21}`);
+    const server = app.listen(PORT, HOST, () => {
+      const pkg = require('../package.json');
+      logger.info(`FireAlive v${pkg.version} running on http://${HOST}:${PORT}`);
       validatePortBinding(server, parseInt(PORT, 10));
     });
+
+    // Initialize WebSocket server for real-time features
+    try {
+      const wsServer = new FireAliveWebSocket(server, app.locals?.db);
+      wsServer.startHeartbeatCheck();
+      logger.info('WebSocket server started on /ws');
+      process.on('SIGTERM', () => { wsServer.shutdown(); server.close(); });
+      process.on('SIGINT', () => { wsServer.shutdown(); server.close(); });
+    } catch (e) {
+      logger.warn('WebSocket init skipped', { error: e.message });
+    }
   } catch (err) {
     logger.error('Failed to start:', err);
     process.exit(1);
@@ -203,12 +214,3 @@ async function start() {
 start();
 
 module.exports = app;  // for testing
-
-// Initialize WebSocket server for real-time features
-try {
-  const wsServer = new FireAliveWebSocket(server, app.locals?.db);
-  wsServer.startHeartbeatCheck();
-  console.log('[WS] WebSocket server started on /ws');
-  process.on('SIGTERM', () => { wsServer.shutdown(); server.close(); });
-  process.on('SIGINT', () => { wsServer.shutdown(); server.close(); });
-} catch (e) { console.warn('[WS] WebSocket init skipped:', e.message); }


### PR DESCRIPTION
## What

Repairs `server/index.js` so the server can actually start.

## Why

The v1.0.8 zip contains a duplicated variable declaration (`const server = const server = app.listen(...)`) that is a hard JavaScript syntax error. The server has not been startable since the v1.0.8 build. This is the first of two prerequisites for everything else in the FireAlive rebuild — until the server boots, no API endpoint can be tested, no frontend can talk to it, and no integration can be validated.

## Changes

- Fix syntax error on line 192 (duplicated `const server`)
- Replace hardcoded `v0.0.21` startup log with version read from `package.json`
- Move WebSocket initialization inside `start()` so `server` is in scope
- Replace `console.log`/`console.warn` in WebSocket init with `logger.info`/`logger.warn`
- Remove the orphan WebSocket initialization block at the bottom of the file (it never worked — `server` was undefined there)

## Companion PR

This is part 1 of Phase 1.1. The companion PR (Phase 1.1 part 2) repairs `server/db/init.js`, which has its own out-of-scope code at the bottom that also crashes on `require()`. Both must land for the server to start.

## Verification

After merging both Phase 1.1 PRs:
- `node -c server/index.js` parses without error
- `npm start` boots without crashing
- The startup log line shows the real version from `package.json`

## Phase context

This is Phase 1, step 1.1 of the FireAlive rebuild plan. Phase 1 is "backend foundation — server actually starts and is internally consistent." Step 1.1 is "repair the server boot path." Step 1.2 (next) is the canonical version source of truth across all server files.