### PR TITLE
Phase 1.1 (2/2): Remove orphan code from server/db/init.js

### DIFF
--- a/server/db/init.js
+++ b/server/db/init.js
@@ -420,6 +420,35 @@ CREATE TABLE IF NOT EXISTS config (
   key TEXT PRIMARY KEY,
   value TEXT NOT NULL
 );
+
+CREATE TABLE IF NOT EXISTS ticket_actions (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  analyst_id TEXT,
+  ticket_id TEXT,
+  category TEXT,
+  action TEXT,
+  response_time_min REAL,
+  created_at TEXT DEFAULT (datetime('now'))
+);
+
+CREATE TABLE IF NOT EXISTS ticket_assignments (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  analyst_id TEXT,
+  ticket_id TEXT,
+  priority TEXT,
+  status TEXT DEFAULT 'open',
+  assigned_at TEXT DEFAULT (datetime('now')),
+  closed_at TEXT
+);
+
+CREATE TABLE IF NOT EXISTS peer_sessions (
+  id TEXT PRIMARY KEY,
+  helper_id TEXT,
+  seeker_id TEXT,
+  duration_min INTEGER,
+  rating INTEGER,
+  created_at TEXT DEFAULT (datetime('now'))
+);
 `;
 
 function initDb() {
@@ -451,8 +480,3 @@ if (require.main === module) {
 }
 
 module.exports = { getDb, initDb, DB_PATH };
-
-db.prepare("CREATE TABLE IF NOT EXISTS ticket_actions (id INTEGER PRIMARY KEY AUTOINCREMENT, analyst_id TEXT, ticket_id TEXT, category TEXT, action TEXT, response_time_min REAL, created_at TEXT DEFAULT (datetime('now')))").run();
-db.prepare("CREATE TABLE IF NOT EXISTS ticket_assignments (id INTEGER PRIMARY KEY AUTOINCREMENT, analyst_id TEXT, ticket_id TEXT, priority TEXT, status TEXT DEFAULT 'open', assigned_at TEXT DEFAULT (datetime('now')), closed_at TEXT)").run();
-db.prepare("CREATE TABLE IF NOT EXISTS peer_sessions (id TEXT PRIMARY KEY, helper_id TEXT, seeker_id TEXT, duration_min INTEGER, rating INTEGER, created_at TEXT DEFAULT (datetime('now')))").run();
-db.prepare("CREATE TABLE IF NOT EXISTS helper_ratings (id INTEGER PRIMARY KEY AUTOINCREMENT, session_id TEXT, helper_uuid TEXT, rating INTEGER, points INTEGER, created_at TEXT DEFAULT (datetime('now')))").run();


### PR DESCRIPTION
## What

Repairs `server/db/init.js` so it can be `require()`d without crashing.

## Why

Four `db.prepare(...).run()` calls existed at the bottom of the file, after `module.exports`, at module top-level. They referenced a `db` variable that was only in scope inside the `initDb()` function. Loading the module would throw `ReferenceError: db is not defined` immediately, before any caller could even call `initDb()`. This means the server could never have initialized its database, regardless of the syntax error in `server/index.js` (handled in the companion PR).

## Changes

- Move `ticket_actions`, `ticket_assignments`, and `peer_sessions` tables into the canonical `SCHEMA` constant so they are created in the same `db.exec(SCHEMA)` pass as every other table
- Delete the four orphan `db.prepare(...).run()` lines at the bottom of the file
- `helper_ratings` table is **not** migrated — it is only used by `routes/v054-features.js`, which is unmounted dead code that Phase 1.4 will remove entirely

## Companion PR

This is part 2 of Phase 1.1. Part 1 fixes the syntax error and WebSocket scope in `server/index.js`. Both must land for the server to start.

## Verification

After merging both Phase 1.1 PRs:
- `node -e "require('./server/db/init.js')"` does not throw
- `npm start` calls `initDb()` successfully and creates all tables
- `services/signal-collector.js` and `services/metrics-collector.js` can query their expected tables without crashing

## Phase context

Phase 1, step 1.1 of the FireAlive rebuild — "repair the server boot path." Step 1.2 is next: canonical version source of truth across all server files.
