### PR TITLE
Phase 1.2 (1/2): Canonical version module + boot-critical migration

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,12 +1,15 @@
 {
   "name": "firealive",
   "version": "1.0.8",
-  "description": "**Version:** v1.0.8 | **License:** AGPL-3.0-or-later | **Author:** Peter Mancina   **E-fuse counter:** 1 (anti-rollback)",
-  "main": "index.js",
+  "fuseCounter": 1,
+  "buildId": "20260429.1",
+  "description": "FireAlive — SOC Analyst Wellbeing Platform. Burnout-aware ticket routing, peer skill-share, post-incident wellness, skills assessments, and team health monitoring with privacy-first architecture.",
+  "main": "server/index.js",
   "directories": {
     "doc": "docs"
   },
   "scripts": {
+    "start": "node server/index.js",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "repository": {
@@ -15,7 +18,7 @@
   },
   "keywords": [],
   "author": "",
-  "license": "ISC",
+  "license": "AGPL-3.0-or-later",
   "type": "commonjs",
   "bugs": {
     "url": "https://github.com/petermancina/firealive/issues"

--- a/server/db/init.js
+++ b/server/db/init.js
@@ -452,6 +452,7 @@ CREATE TABLE IF NOT EXISTS peer_sessions (
 `;
 
 function initDb() {
+  const { version, fuseCounter } = require('../lib/version');
   const db = getDb();
 
   // Execute schema
@@ -459,8 +460,8 @@ function initDb() {
 
   // Set initial system metadata
   const setMeta = db.prepare('INSERT OR IGNORE INTO system_meta (key, value) VALUES (?, ?)');
-  setMeta.run('fuse_counter', '31');
-  setMeta.run('app_version', '0.0.31');
+  setMeta.run('fuse_counter', String(fuseCounter));
+  setMeta.run('app_version', version);
   setMeta.run('schema_version', '1');
   setMeta.run('installed_at', new Date().toISOString());
 

--- a/server/lib/version.js
+++ b/server/lib/version.js
@@ -1,0 +1,38 @@
+// ═══════════════════════════════════════════════════════════════════════════════
+// FIREALIVE — Canonical Version Module
+//
+// Single source of truth for application version, anti-rollback fuse counter,
+// and build identifier. All server-side code that needs to report version
+// information MUST require this module rather than hardcoding strings.
+//
+// The values are read from package.json at startup. The version module is
+// the only place in the codebase that reads package.json for version data.
+// ═══════════════════════════════════════════════════════════════════════════════
+
+const path = require('path');
+
+const pkg = require(path.join(__dirname, '..', '..', 'package.json'));
+
+if (typeof pkg.version !== 'string' || !pkg.version) {
+  throw new Error('package.json is missing a "version" field');
+}
+
+if (typeof pkg.fuseCounter !== 'number') {
+  throw new Error('package.json is missing a numeric "fuseCounter" field — required for anti-rollback');
+}
+
+const version = pkg.version;
+const fuseCounter = pkg.fuseCounter;
+const buildId = typeof pkg.buildId === 'string' ? pkg.buildId : null;
+
+// Convenience labels for log lines and CEF fields
+const versionLabel = `v${version}`;
+const cefDeviceVersion = version;
+
+module.exports = {
+  version,
+  versionLabel,
+  fuseCounter,
+  buildId,
+  cefDeviceVersion,
+};

--- a/server/routes/system.js
+++ b/server/routes/system.js
@@ -13,9 +13,11 @@ const { getDb } = require('../db/init');
 const { auditLog } = require('../middleware/audit');
 const { logger } = require('../services/logger');
 
-const APP_VERSION = '0.0.21';
-const FUSE_COUNTER = 21;
-const BUILD_ID = `20260404.1`;
+const { version, fuseCounter, buildId } = require('../lib/version');
+
+const APP_VERSION = version;
+const FUSE_COUNTER = fuseCounter;
+const BUILD_ID = buildId;
 
 // ── Health Check ─────────────────────────────────────────────────────────────
 router.get('/health', (req, res) => {
@@ -112,21 +114,22 @@ router.post('/fuse-check', (req, res) => {
   }
 });
 
-// ── Update Check (Simulated) ─────────────────────────────────────────────────
+// ── Update Check ─────────────────────────────────────────────────────────────
+// Returns the running version. In a real deployment this would also poll a
+// secure update server (Ed25519-signed release feed) for the latest available
+// version. Until that infrastructure exists, this endpoint simply reports the
+// current version and explicitly notes that no update server is configured.
 router.post('/update-check', (req, res) => {
-  // In production, this would call a secure update server
   const currentVersion = APP_VERSION;
-  const latestVersion = '0.0.20'; // simulated
 
-  const updateAvailable = latestVersion !== currentVersion;
-
-  auditLog(req.user?.id, 'UPDATE_CHECK', `current=${currentVersion} latest=${latestVersion}`, req.ip);
+  auditLog(req.user?.id, 'UPDATE_CHECK', `current=${currentVersion}`, req.ip);
 
   res.json({
     currentVersion,
-    latestVersion,
-    updateAvailable,
-    releaseNotes: updateAvailable ? 'Expand KB to 50+ sources, IAM/AD wizard improvements, report engine scheduling' : null,
+    latestVersion: null,
+    updateAvailable: false,
+    updateServerConfigured: false,
+    note: 'No update server configured. Configure FIREALIVE_UPDATE_SERVER_URL to enable update checks.',
     checkedAt: new Date().toISOString(),
   });
 });


### PR DESCRIPTION
## What

Introduces `server/lib/version.js` as the single source of truth for application version, anti-rollback fuse counter, and build identifier. Migrates the boot-critical files (`package.json`, `db/init.js`, `routes/system.js`) to consume it.

## Why

The v1.0.8 codebase has version strings hardcoded in at least 14 places, with values ranging from `0.0.18` to `0.0.31` while `package.json` reports `1.0.8`. This is the kind of drift that makes a release notes file lie about itself, makes CEF SIEM events report the wrong version, and makes anti-rollback fuse counters meaningless. A real app reads version from one place.

## Changes

- `package.json` — adds `fuseCounter: 1` and `buildId: "20260429.1"` fields; cleans up `description`; sets `main` to `server/index.js`; adds `start` script; corrects license to `AGPL-3.0-or-later` (codebase is AGPL throughout, package.json incorrectly said ISC).
- **NEW** `server/lib/version.js` — reads `package.json`, validates required fields, exports `version`, `versionLabel`, `fuseCounter`, `buildId`, `cefDeviceVersion`. Throws on startup if `version` or `fuseCounter` are missing or wrong type.
- `server/db/init.js` — `initDb()` reads version + fuseCounter from `server/lib/version` instead of hardcoded `'0.0.31'` and `'31'`.
- `server/routes/system.js` — `APP_VERSION`, `FUSE_COUNTER`, `BUILD_ID` constants come from `server/lib/version`. Removes the fake `latestVersion = '0.0.20'` from `/api/system/update-check` (it always reported a fake update available); replaced with an honest "no update server configured" response.

## Companion PR

This is part 1 of Phase 1.2. Part 2 migrates the remaining ~10 server files (logger, scheduler, soar-alerting, integrity, compliance, audit middleware, siem integration, audit/reports/v021/v022/v023/v027/compliance-monitoring routes) off their hardcoded version strings. Both PRs land cleanly on top of Phase 1.1.

## Verification

After merging:
- `npm start` boots, log line shows `FireAlive v1.0.8 running on http://...`
- `curl localhost:3000/api/system/health` returns `{"status":"healthy","version":"1.0.8","fuse":1,...}`
- `/api/system/update-check` (with auth) returns `{"currentVersion":"1.0.8","latestVersion":null,"updateAvailable":false,"updateServerConfigured":false,...}` — no more fake update
- Fresh database install records `fuse_counter=1` and `app_version=1.0.8` in `system_meta`

## Existing installs

`system_meta` uses `INSERT OR IGNORE`, so existing databases initialized with `0.0.31` will keep that value. That's intentional — `app_version` in `system_meta` tracks the version that first initialized the schema, not the current running version.

## Phase context

Phase 1, step 1.2 — canonical version source of truth. Step 1.3 (next) consolidates the database schema.
