### PR TITLE
Phase 1.2 (2/2): Migrate remaining server files to canonical version module

### DIFF
--- a/server/integrations/siem.js
+++ b/server/integrations/siem.js
@@ -9,6 +9,7 @@
 
 const dgram = require('dgram');
 const { logger } = require('../services/logger');
+const { cefDeviceVersion } = require('../lib/version');
 
 class SiemClient {
   constructor(config) {
@@ -91,7 +92,7 @@ class SiemClient {
     const version = 0;
     const vendor = 'FireAlive';
     const product = 'WellbeingPlatform';
-    const deviceVersion = '0.0.19';
+    const deviceVersion = cefDeviceVersion;
     const sigId = event.signatureId || 'UNKNOWN';
     const name = event.name || 'FireAlive Event';
     const severity = event.severity || 5;

--- a/server/middleware/audit.js
+++ b/server/middleware/audit.js
@@ -6,11 +6,12 @@
 
 const { getDb } = require('../db/init');
 const { logger } = require('../services/logger');
+const { cefDeviceVersion } = require('../lib/version');
 
 function formatCEF(event, userId, detail, ip) {
   const ts = new Date().toISOString();
   // CEF:Version|Device Vendor|Device Product|Device Version|Signature ID|Name|Severity|Extension
-  return `CEF:0|FireAlive|WellbeingPlatform|0.0.18|${event}|${event}|3|rt=${ts} suser=${userId || 'anonymous'} msg=${(detail || '').replace(/[|\\]/g, '_')} src=${ip || ''}`;
+  return `CEF:0|FireAlive|WellbeingPlatform|${cefDeviceVersion}|${event}|${event}|3|rt=${ts} suser=${userId || 'anonymous'} msg=${(detail || '').replace(/[|\\]/g, '_')} src=${ip || ''}`;
 }
 
 function auditMiddleware(req, res, next) {

--- a/server/middleware/audit.js
+++ b/server/middleware/audit.js
@@ -11,7 +11,7 @@ const { cefDeviceVersion } = require('../lib/version');
 function formatCEF(event, userId, detail, ip) {
   const ts = new Date().toISOString();
   // CEF:Version|Device Vendor|Device Product|Device Version|Signature ID|Name|Severity|Extension
-  return `CEF:0|FireAlive|WellbeingPlatform|${cefDeviceVersion}|${event}|${event}|3|rt=${ts} suser=${userId || 'anonymous'} msg=${(detail || '').replace(/[|\\]/g, '_')} src=${ip || ''}`;
+    return `CEF:0|FireAlive|WellbeingPlatform|${cefDeviceVersion}|${event}|${event}|3|rt=${ts} suser=${userId || 'anonymous'} msg=${(detail || '').replace(/[|\\]/g, '_')} src=${ip || ''}`;
 }
 
 function auditMiddleware(req, res, next) {

--- a/server/routes/audit.js
+++ b/server/routes/audit.js
@@ -8,6 +8,7 @@
 const router = require('express').Router();
 const { getDb } = require('../db/init');
 const { logger } = require('../services/logger');
+const { cefDeviceVersion } = require('../lib/version');
 
 // ── Query Audit Log ──────────────────────────────────────────────────────────
 router.get('/', (req, res) => {
@@ -76,7 +77,7 @@ router.get('/export', (req, res) => {
     }
 
     if (format === 'cef') {
-      const cefLines = rows.map(r => r.cef_message || `CEF:0|FireAlive|WellbeingPlatform|0.0.19|${r.event_type}|${r.event_type}|5|src=${r.ip_address || ''} suser=${r.user_name || ''} msg=${r.detail || ''}`);
+      const cefLines = rows.map(r => r.cef_message || `CEF:0|FireAlive|WellbeingPlatform|${cefDeviceVersion}|${r.event_type}|${r.event_type}|5|src=${r.ip_address || ''} suser=${r.user_name || ''} msg=${r.detail || ''}`);
       res.setHeader('Content-Type', 'text/plain');
       res.setHeader('Content-Disposition', `attachment; filename=firealive-audit-${new Date().toISOString().slice(0, 10)}.cef`);
       return res.send(cefLines.join('\n'));

--- a/server/routes/compliance-monitoring.js
+++ b/server/routes/compliance-monitoring.js
@@ -22,6 +22,7 @@ const { logger } = require('../services/logger');
 const { generateComplianceReport, FRAMEWORKS, signLogBatch, toSyslog, getSeverity, SEVERITY_LABELS } = require('../services/compliance');
 const { runRetentionPurge, getRetentionConfig, DEFAULT_RETENTION } = require('../services/retention');
 const { runtimeMonitor } = require('../services/runtime-monitor');
+const { version } = require('../lib/version');
 
 // ── Compliance Reports ───────────────────────────────────────────────────────
 router.get('/compliance/report/:framework', (req, res) => {
@@ -66,7 +67,7 @@ router.get('/monitoring/health-detail', (req, res) => {
     res.json({
       runtime: runtimeMonitor.getMetrics(),
       app: {
-        version: '0.0.20',
+        version,
         fuse: parseInt(fuse?.value, 10),
         panicMode: panicMode?.value === '"active"',
         users: userCount.c,
@@ -180,7 +181,7 @@ router.get('/audit/export-forensics', (req, res) => {
     // Structured JSON for general forensics tools
     const forensicsData = {
       exportType: 'firealive_forensics',
-      version: '0.0.20',
+      version,
       exportedAt: new Date().toISOString(),
       eventCount: events.length,
       integrity: signLogBatch(events),

--- a/server/routes/reports.js
+++ b/server/routes/reports.js
@@ -12,6 +12,7 @@ const crypto = require('crypto');
 const { getDb } = require('../db/init');
 const { auditLog } = require('../middleware/audit');
 const { logger } = require('../services/logger');
+const { version } = require('../lib/version');
 
 // ── List Reports ─────────────────────────────────────────────────────────────
 router.get('/', (req, res) => {
@@ -63,7 +64,7 @@ router.post('/generate', (req, res) => {
     const format = req.body.format || configRow?.format || 'json';
 
     // ── Gather data ────────────────────────────────────────────────────────
-    const report = { generatedAt: new Date().toISOString(), version: '0.0.19', sections: {} };
+    const report = { generatedAt: new Date().toISOString(), version, sections: {} };
     let sectionCount = 0;
 
     // Team Health (depersonalized)

--- a/server/routes/v021-features.js
+++ b/server/routes/v021-features.js
@@ -10,6 +10,7 @@ const crypto = require('crypto');
 const { getDb } = require('../db/init');
 const { auditLog } = require('../middleware/audit');
 const { logger } = require('../services/logger');
+const { version } = require('../lib/version');
 
 // ── Vulnerability Scanner Integration ────────────────────────────────────────
 // Allows approved scanners (Nessus, OpenVAS, Qualys) to scan the app.
@@ -139,7 +140,7 @@ router.get('/config/export', (req, res) => {
 
     const exportData = {
       exportType: 'firealive_config',
-      version: '0.0.21',
+      version,
       exportedAt: new Date().toISOString(),
       checksum: null,
       teamConfig, reportConfig, slaConfig, notifConfig,
@@ -171,7 +172,7 @@ router.get('/config/change-report', (req, res) => {
     res.json({
       reportType: 'configuration_change_management',
       generatedAt: new Date().toISOString(),
-      version: '0.0.21',
+      version,
       changeCount: configChanges.length,
       changes: configChanges,
     });

--- a/server/routes/v022-features.js
+++ b/server/routes/v022-features.js
@@ -10,6 +10,7 @@ const crypto = require('crypto');
 const { getDb } = require('../db/init');
 const { auditLog } = require('../middleware/audit');
 const { logger } = require('../services/logger');
+const { version, versionLabel } = require('../lib/version');
 
 // ── Client Notification Configuration ───────────────────────────────────────
 // Team leads configure how analysts receive notifications.
@@ -312,7 +313,7 @@ router.delete('/peer-board/:id', (req, res) => {
 router.post('/security/regression-test', (req, res) => {
   try {
     const db = getDb();
-    const results = { timestamp: new Date().toISOString(), version: '0.0.22', checks: [], passed: 0, failed: 0, warnings: 0 };
+    const results = { timestamp: new Date().toISOString(), version, checks: [], passed: 0, failed: 0, warnings: 0 };
 
     // Check 1: SIEM connectivity
     const siemConfig = db.prepare("SELECT value FROM team_config WHERE key = 'siem_config'").get();
@@ -335,7 +336,7 @@ router.post('/security/regression-test', (req, res) => {
         id: 'SOAR_COMPAT', name: 'SOAR Platform Compatibility',
         status: supported.includes(soar.platform) ? 'pass' : 'warning',
         detail: `Platform: ${soar.platform}`,
-        recommendation: supported.includes(soar.platform) ? null : `SOAR platform "${soar.platform}" may not be fully supported in v0.0.22. Verify webhook and API compatibility.`,
+        recommendation: supported.includes(soar.platform) ? null : `SOAR platform "${soar.platform}" may not be fully supported in ${versionLabel}. Verify webhook and API compatibility.`,
       });
     }
 
@@ -462,7 +463,7 @@ router.post('/soar/generate-playbook', (req, res) => {
 
   const playbook = {
     title: `FireAlive Incident Response Playbook: ${type.name}`,
-    version: '0.0.22',
+    version,
     generatedAt: new Date().toISOString(),
     incidentType,
     phases: ['detect', 'triage', 'contain', 'investigate', 'remediate', 'recover', 'review'],

--- a/server/routes/v023-features.js
+++ b/server/routes/v023-features.js
@@ -9,6 +9,7 @@ const crypto = require('crypto');
 const { getDb } = require('../db/init');
 const { auditLog } = require('../middleware/audit');
 const { logger } = require('../services/logger');
+const { version } = require('../lib/version');
 
 // ── Human Impact Risk Report ────────────────────────────────────────────────
 // Generates a report linking incident types to analyst burnout metrics,
@@ -28,7 +29,7 @@ router.get('/reports/human-impact-risk', (req, res) => {
 
     const report = {
       reportType: 'human_impact_risk_assessment',
-      version: '0.0.23',
+      version,
       generatedAt: new Date().toISOString(),
       methodology: 'Links SOC incident types to analyst behavioral drift signals (investigation time, dismiss rate, documentation quality, escalation patterns) to estimate human capital impact. Designed for incorporation into enterprise risk registers alongside traditional financial and operational impact metrics.',
 

--- a/server/routes/v027-features.js
+++ b/server/routes/v027-features.js
@@ -10,6 +10,7 @@ const crypto = require('crypto');
 const { getDb } = require('../db/init');
 const { auditLog } = require('../middleware/audit');
 const { logger } = require('../services/logger');
+const { version } = require('../lib/version');
 
 // ── Proactive Break Interventions ───────────────────────────────────────────
 router.get('/proactive/config', (req, res) => {
@@ -237,7 +238,7 @@ router.post('/legal-hold/export', (req, res) => {
 
     const exportData = {
       exportType: 'legal_hold',
-      version: '0.0.27',
+      version,
       exportedAt: new Date().toISOString(),
       chainOfCustody: {
         exportedBy: req.user?.id || 'system',

--- a/server/services/compliance.js
+++ b/server/services/compliance.js
@@ -9,6 +9,7 @@
 const crypto = require('crypto');
 const { getDb } = require('../db/init');
 const { logger } = require('./logger');
+const { version } = require('../lib/version');
 
 // ── Syslog Severity Mapping (RFC 5424) ───────────────────────────────────────
 const SEVERITY_MAP = {
@@ -224,7 +225,7 @@ function generateComplianceReport(framework) {
   return {
     framework: fw.name,
     generatedAt: new Date().toISOString(),
-    appVersion: '0.0.20',
+    appVersion: version,
     summary: { total: results.length, passed, warnings, failed },
     note: fw.note || null,
     controls: results,

--- a/server/services/integrity.js
+++ b/server/services/integrity.js
@@ -12,6 +12,7 @@
 const crypto = require('crypto');
 const fs = require('fs');
 const path = require('path');
+const { version } = require('../lib/version');
 
 const SERVER_ROOT = path.join(__dirname, '..');
 const MANIFEST_PATH = path.join(SERVER_ROOT, '..', 'config', 'integrity-manifest.json');
@@ -47,7 +48,7 @@ function collectFiles() {
 function generateManifest() {
   const files = collectFiles();
   const manifest = {
-    version: '0.0.19',
+    version,
     generatedAt: new Date().toISOString(),
     algorithm: 'sha256',
     fileCount: Object.keys(files).length,

--- a/server/services/logger.js
+++ b/server/services/logger.js
@@ -5,6 +5,7 @@
 const winston = require('winston');
 const path = require('path');
 const fs = require('fs');
+const pkgVersion = require(path.join(__dirname, '..', '..', 'package.json')).version;
 
 const logDir = process.env.LOG_PATH || path.join(__dirname, '../../data/logs');
 if (!fs.existsSync(logDir)) fs.mkdirSync(logDir, { recursive: true });
@@ -16,7 +17,7 @@ const logger = winston.createLogger({
     winston.format.errors({ stack: true }),
     winston.format.json()
   ),
-  defaultMeta: { service: 'firealive', version: '0.0.18' },
+  defaultMeta: { service: 'firealive', version: pkgVersion },
   transports: [
     new winston.transports.File({
       filename: path.join(logDir, 'error.log'),

--- a/server/services/scheduler.js
+++ b/server/services/scheduler.js
@@ -6,6 +6,7 @@
 
 const cron = require('node-cron');
 const { logger } = require('./logger');
+const { versionLabel } = require('../lib/version');
 
 const schedulerService = {
   jobs: [],
@@ -82,7 +83,7 @@ function generateReport(db, config, type) {
 
   const report = {
     generated: new Date().toISOString(),
-    platform: 'FireAlive v0.0.18',
+    platform: `FireAlive ${versionLabel}`,
     type,
     depersonalized: true,
     sections: {},

--- a/server/services/soar-alerting.js
+++ b/server/services/soar-alerting.js
@@ -8,6 +8,7 @@
 const { getDb } = require('../db/init');
 const { logger } = require('./logger');
 const { auditLog } = require('../middleware/audit');
+const { version } = require('../lib/version');
 
 const ALERT_TYPES = {
   FIM_FILE_MODIFIED: { severity: 'critical', action: 'investigate_app_compromise', containment: 'isolate_host' },
@@ -48,7 +49,7 @@ async function dispatchToSoar(alertType, details) {
     // Build SOAR alert payload
     const payload = {
       source: 'firealive',
-      version: '0.0.21',
+      version,
       alertType,
       severity: config.severity,
       suggestedAction: config.action,


### PR DESCRIPTION
## What

Migrates all remaining server-side files off hardcoded version strings to consume `server/lib/version.js`.

## Why

PR 1 of Phase 1.2 established `server/lib/version.js` as the single source of truth and migrated the boot-critical files. This PR finishes the job by migrating the remaining 14 files where version strings were hardcoded with values ranging from `0.0.18` to `0.0.27`.

After this PR lands, every CEF event, SIEM payload, SOAR alert, report header, integrity manifest, legal hold export, and runtime health response reports the same version — the one in `package.json`.

## Changes

20 surgical edits across 14 files, one commit per file. Each edit follows the same pattern: add a `require` line for `server/lib/version`, then replace the hardcoded string with the imported variable.

`server/services/logger.js` is the one special case — it reads `package.json` directly instead of going through `server/lib/version` to avoid a require cycle (the logger is required by many things, including consumers of the version module). It is the only file outside `server/lib/version.js` that reads `package.json` directly.

## Files migrated

- `server/services/logger.js` (was 0.0.18)
- `server/middleware/audit.js` (was 0.0.18)
- `server/services/scheduler.js` (was 0.0.18)
- `server/services/soar-alerting.js` (was 0.0.21)
- `server/services/integrity.js` (was 0.0.19)
- `server/services/compliance.js` (was 0.0.20)
- `server/integrations/siem.js` (was 0.0.19)
- `server/routes/audit.js` (was 0.0.19)
- `server/routes/reports.js` (was 0.0.19)
- `server/routes/v021-features.js` (was 0.0.21 in two places)
- `server/routes/v022-features.js` (was 0.0.22 in three places)
- `server/routes/v023-features.js` (was 0.0.23)
- `server/routes/v027-features.js` (was 0.0.27)
- `server/routes/compliance-monitoring.js` (was 0.0.20 in two places)

## Files explicitly NOT touched

- `server/routes/v054-features.js` — unmounted dead code, scheduled for removal in Phase 1.4
- File header comments like `// FIREALIVE v0.0.21 — New Routes` — historical "introduced in" markers, cleaned up alongside route consolidation in Phase 2
- `packages/global-dashboard-server/*` — separate package with its own `package.json`; migrated in Phase 4

## Verification

After merging:
- `grep -rn "0\\.0\\.[0-9]" server/ --include="*.js" | grep -v "v0\\.0\\." | grep -v "FIREALIVE v0\\.0"` returns no matches outside `routes/v054-features.js`
- `npm start` boots successfully
- `/api/system/health` returns version `1.0.8`
- A CEF event emitted by audit middleware contains `WellbeingPlatform|1.0.8|...`
- A generated compliance report contains `appVersion: "1.0.8"`
- A regression-test response contains `version: "1.0.8"`

## Phase context

Phase 1, step 1.2 complete with this PR. Step 1.3 (next) consolidates the database schema — moving the `_initTables()` methods scattered across service classes (AssessmentService, BackupService, etc.) into `db/init.js`'s canonical SCHEMA.
