### PR TITLE
Phase 1.3: Consolidate database schema

### DIFF
--- a/server/db/init.js
+++ b/server/db/init.js
@@ -449,7 +449,36 @@ CREATE TABLE IF NOT EXISTS peer_sessions (
   rating INTEGER,
   created_at TEXT DEFAULT (datetime('now'))
 );
+
+CREATE TABLE IF NOT EXISTS analyst_baselines (
+  analyst_id TEXT PRIMARY KEY,
+  cognitive_load REAL,
+  task_switching REAL,
+  queue_pressure REAL,
+  response_latency REAL,
+  break_compliance REAL,
+  shift_overtime REAL,
+  established_at TEXT,
+  sample_count INTEGER DEFAULT 0
+);
+
+CREATE TABLE IF NOT EXISTS signal_readings (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  analyst_id TEXT,
+  signal TEXT,
+  value REAL,
+  recorded_at TEXT DEFAULT (datetime('now'))
+);
+
+CREATE TABLE IF NOT EXISTS analyst_impacts (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  analyst_id TEXT,
+  type TEXT,
+  description TEXT,
+  recorded_at TEXT DEFAULT (datetime('now'))
+);
 `;
+
 
 function initDb() {
   const { version, fuseCounter } = require('../lib/version');

--- a/server/routes/v023-features.js
+++ b/server/routes/v023-features.js
@@ -22,7 +22,7 @@ router.get('/reports/human-impact-risk', (req, res) => {
     // Gather incident-to-burnout correlation data
     // In production, this queries real ticket/incident data linked to analyst metrics.
     // For now, generates a structured report from available data.
-    const analysts = db.prepare("SELECT * FROM analysts").all();
+    const analysts = db.prepare("SELECT * FROM users WHERE role = 'analyst'").all();
     const incidents = db.prepare("SELECT * FROM audit_log WHERE event_type LIKE '%INCIDENT%' OR event_type LIKE '%RETRO%' OR event_type LIKE '%ROUTING%' ORDER BY timestamp DESC LIMIT 500").all();
 
     db.close();

--- a/server/services/ai-burnout-engine.js
+++ b/server/services/ai-burnout-engine.js
@@ -7,26 +7,6 @@
 class AiBurnoutEngine {
   constructor(db) {
     this.db = db;
-    this._initTables();
-  }
-
-  _initTables() {
-    this.db.prepare(`CREATE TABLE IF NOT EXISTS analyst_baselines (
-      analyst_id TEXT PRIMARY KEY,
-      cognitive_load REAL, task_switching REAL, queue_pressure REAL,
-      response_latency REAL, break_compliance REAL, shift_overtime REAL,
-      established_at TEXT, sample_count INTEGER DEFAULT 0
-    )`).run();
-    this.db.prepare(`CREATE TABLE IF NOT EXISTS signal_readings (
-      id INTEGER PRIMARY KEY AUTOINCREMENT,
-      analyst_id TEXT, signal TEXT, value REAL,
-      recorded_at TEXT DEFAULT (datetime('now'))
-    )`).run();
-    this.db.prepare(`CREATE TABLE IF NOT EXISTS analyst_impacts (
-      id INTEGER PRIMARY KEY AUTOINCREMENT,
-      analyst_id TEXT, type TEXT, description TEXT,
-      recorded_at TEXT DEFAULT (datetime('now'))
-    )`).run();
   }
 
   // Record a signal reading from the AC


### PR DESCRIPTION
## What

Brings the `analyst_baselines`, `signal_readings`, and `analyst_impacts` tables into the canonical `SCHEMA` constant in `server/db/init.js`. Removes the `_initTables()` pattern from the only service class that's actually instantiated at runtime (`ai-burnout-engine.js`). Fixes a route that was querying a nonexistent table.

## Why

Phase 1.3's goal is "the canonical schema lives in exactly one place: `db/init.js`." Before this PR, `ai-burnout-engine.js` was creating its own three tables every time it was instantiated, which meant schema definition was scattered across the codebase in ways that were easy to miss. The pattern also meant tables only existed if the right service class happened to be loaded — fine in practice for `ai-burnout-engine` (it's loaded by `websocket-server.js` on startup), but a footgun for any future service.

A separate concrete bug surfaced during the audit: `routes/v023-features.js` called `SELECT * FROM analysts`, but no such table exists in the schema. Analyst records live in `users` with `role='analyst'` everywhere else in the codebase. That endpoint was returning a 500 error to anyone who hit it.

## Changes

- **commit 1** — `server/db/init.js`: adds `analyst_baselines`, `signal_readings`, and `analyst_impacts` to the `SCHEMA` constant. The shapes match exactly what `ai-burnout-engine.js` was creating before.
- **commit 2** — `server/services/ai-burnout-engine.js`: removes the `_initTables()` method and the constructor's call to it. The class is now a pure consumer of tables defined in `db/init.js`.
- **commit 3** — `server/routes/v023-features.js`: fixes the broken `SELECT * FROM analysts` query in the `/risk/human-impact` route by replacing it with `SELECT * FROM users WHERE role = 'analyst'`.

## Files explicitly NOT touched

Five other service classes in `server/services/` also use the `_initTables()` pattern: `assessment-service.js`, `feature-toggles.js`, `backup-service.js`, `integration-manager.js`, `notification-service.js`. **None of these classes are instantiated anywhere in the codebase** — they're dead code, alongside `routes/v054-features.js` and the v054/v059/v100 route family. They will be removed entirely in Phase 1.4 rather than migrated, because migrating dead code is wasted work. Their `_initTables()` methods do create real tables on import test runs, but those tables are never queried by any mounted route.

The three tables migrated in Phase 1.1 PR 2 (`ticket_actions`, `ticket_assignments`, `peer_sessions`) currently lack `REFERENCES users(id)` foreign keys despite SCHEMA's other tables consistently using them. SQLite cannot add foreign keys to existing tables without a full table rebuild, which is migration-risky for existing installs. FK additions are deferred to a dedicated schema-versioning effort in a later phase.

## Verification

After merging:
- `node -e "const { initDb } = require('./server/db/init.js'); initDb();"` runs without errors and creates all expected tables, including the three new ones.
- The WebSocket server's signal collection cycle (which lazily requires `AiBurnoutEngine`) works correctly without the engine creating tables on its own.
- A request to `POST /api/risk/human-impact` (with appropriate auth) returns a real risk report instead of a 500 error from the missing `analysts` table.
- `grep -rn "_initTables\|_initTable\b" server/services/` shows that `ai-burnout-engine.js` no longer has the method (the five other services that still have it are dead code being removed in Phase 1.4).

## Phase context

Phase 1, step 1.3 complete with this PR. Step 1.4 (next, the final step in Phase 1) is the dead-code sweep: removes `routes/v054-features.js` and the five unused service classes, and re-implements the small set of features they were supposed to provide (client restore, IAM confirm-status, upskilling schedule, GD metrics ingest) properly in the working architecture.
