### PR TITLE
Phase 1.4a: In-app notifications backend + first wave of event wirings

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "helmet": "^8.1.0",
     "jsonwebtoken": "^9.0.3",
     "node-cron": "^4.2.1",
+    "nodemailer": "^6.9.16",
     "sharp": "^0.34.5",
     "tweetnacl": "^1.0.3",
     "tweetnacl-util": "^0.15.1",

--- a/server/db/init.js
+++ b/server/db/init.js
@@ -477,6 +477,37 @@ CREATE TABLE IF NOT EXISTS analyst_impacts (
   description TEXT,
   recorded_at TEXT DEFAULT (datetime('now'))
 );
+
+CREATE TABLE IF NOT EXISTS notifications (
+  id TEXT PRIMARY KEY DEFAULT (lower(hex(randomblob(16)))),
+  recipient_id TEXT NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  event_type TEXT NOT NULL,
+  title TEXT NOT NULL,
+  body TEXT,
+  link_tab TEXT,
+  link_params TEXT,
+  read_at TEXT,
+  delivered_in_app INTEGER NOT NULL DEFAULT 1,
+  delivered_email INTEGER NOT NULL DEFAULT 0,
+  email_delivery_status TEXT,
+  created_at TEXT NOT NULL DEFAULT (datetime('now'))
+);
+
+CREATE INDEX IF NOT EXISTS idx_notifications_recipient_unread
+  ON notifications(recipient_id, read_at)
+  WHERE read_at IS NULL;
+
+CREATE INDEX IF NOT EXISTS idx_notifications_recipient_created
+  ON notifications(recipient_id, created_at DESC);
+
+CREATE TABLE IF NOT EXISTS notification_preferences (
+  user_id TEXT NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  event_type TEXT NOT NULL,
+  in_app INTEGER NOT NULL DEFAULT 1,
+  email INTEGER NOT NULL DEFAULT 0,
+  updated_at TEXT NOT NULL DEFAULT (datetime('now')),
+  PRIMARY KEY (user_id, event_type)
+);
 `;
 
 

--- a/server/index.js
+++ b/server/index.js
@@ -120,6 +120,7 @@ app.use('/api/auth/password', require('./routes/password'));
 app.use('/api/restore', authMiddleware(['admin']), require('./routes/restore'));
 app.use('/api/ooda', authMiddleware(['analyst', 'lead', 'admin']), require('./routes/ooda'));
 app.use('/api/inbox', authMiddleware(['analyst', 'lead', 'admin']), require('./routes/notifications-inapp'));
+app.use('/api/inbox/admin', authMiddleware(['admin']), require('./routes/notifications-admin'));
 app.use('/api', authMiddleware(['lead', 'admin']), require('./routes/v021-features'));
 app.use('/api', authMiddleware(['lead', 'admin', 'analyst']), require('./routes/v022-features'));
 app.use('/api', authMiddleware(['lead', 'admin', 'analyst']), require('./routes/v023-features'));

--- a/server/index.js
+++ b/server/index.js
@@ -119,6 +119,7 @@ app.use('/api/query', authMiddleware(['lead', 'admin']), require('./routes/query
 app.use('/api/auth/password', require('./routes/password'));
 app.use('/api/restore', authMiddleware(['admin']), require('./routes/restore'));
 app.use('/api/ooda', authMiddleware(['analyst', 'lead', 'admin']), require('./routes/ooda'));
+app.use('/api/inbox', authMiddleware(['analyst', 'lead', 'admin']), require('./routes/notifications-inapp'));
 app.use('/api', authMiddleware(['lead', 'admin']), require('./routes/v021-features'));
 app.use('/api', authMiddleware(['lead', 'admin', 'analyst']), require('./routes/v022-features'));
 app.use('/api', authMiddleware(['lead', 'admin', 'analyst']), require('./routes/v023-features'));

--- a/server/routes/assessments.js
+++ b/server/routes/assessments.js
@@ -14,6 +14,7 @@ const crypto = require('crypto');
 const { getDb } = require('../db/init');
 const { auditLog } = require('../middleware/audit');
 const { logger } = require('../services/logger');
+const notifications = require('../services/notifications');
 
 const GAP_THRESHOLD = 70; // below this = training recommended
 
@@ -183,14 +184,32 @@ router.post('/:id/assign', (req, res) => {
     if (!assessment) { db.close(); return res.status(404).json({ error: 'Assessment not found' }); }
 
     const insert = db.prepare('INSERT OR IGNORE INTO assessment_assignees (assessment_id, analyst_id) VALUES (?, ?)');
-    let assigned = 0;
+    const newlyAssigned = [];
     for (const aid of analystIds) {
       const result = insert.run(req.params.id, aid);
-      assigned += result.changes;
+      if (result.changes > 0) newlyAssigned.push(aid);
     }
+    const assigned = newlyAssigned.length;
 
     db.close();
     auditLog(req.user.id, 'ASSESSMENT_ASSIGNED', `assessment=${assessment.name} analysts=${assigned}`, req.ip);
+
+    // Notify each newly-assigned analyst (skip duplicates from re-assignment)
+    for (const aid of newlyAssigned) {
+      try {
+        notifications.notify({
+          recipientId: aid,
+          eventType: 'assessment_assigned',
+          title: `New assessment assigned: ${assessment.name}`,
+          body: `A team lead has assigned the "${assessment.name}" skills assessment to you. Open the Skills & Assessments tab to view and submit your scores.`,
+          linkTab: 'skills',
+          linkParams: { assessmentId: req.params.id },
+        });
+      } catch (notifyErr) {
+        logger.warn('Assessment assign: notify failed (non-fatal)', { analystId: aid, error: notifyErr.message });
+      }
+    }
+
     res.json({ ok: true, assigned });
   } catch (err) {
     logger.error('Assign assessment error', { error: err.message });

--- a/server/routes/delegations.js
+++ b/server/routes/delegations.js
@@ -1,6 +1,8 @@
 const router = require('express').Router();
 const { getDb } = require('../db/init');
 const { auditLog } = require('../middleware/audit');
+const { logger } = require('../services/logger');
+const notifications = require('../services/notifications');
 
 router.get('/', (req, res) => {
   const db = getDb();
@@ -22,12 +24,58 @@ router.post('/', (req, res) => {
 });
 
 router.put('/:id/review', (req, res) => {
-  const { status } = req.body; // 'accepted' or 'rejected'
+  const { status, reviewerNotes } = req.body; // status: 'accepted' or 'rejected'
   if (!['accepted', 'rejected'].includes(status)) return res.status(400).json({ error: 'Invalid status' });
+
   const db = getDb();
-  db.prepare('UPDATE delegations SET status = ?, reviewed_by = ?, resolved_at = datetime("now") WHERE id = ?').run(status, req.user.id, req.params.id);
+
+  // Fetch delegation + system name BEFORE the update so we have the analyst to notify and a readable target
+  const existing = db.prepare(`
+    SELECT d.id, d.submitted_by, d.pattern_description, a.name AS system_name
+    FROM delegations d
+    JOIN automation_systems a ON d.target_system_id = a.id
+    WHERE d.id = ?
+  `).get(req.params.id);
+
+  if (!existing) { db.close(); return res.status(404).json({ error: 'Delegation not found' }); }
+
+  db.prepare('UPDATE delegations SET status = ?, reviewed_by = ?, resolved_at = datetime("now") WHERE id = ?')
+    .run(status, req.user.id, req.params.id);
   db.close();
+
   auditLog(req.user.id, 'DELEGATION_REVIEWED', `${req.params.id} → ${status}`, req.ip);
+
+  // Notify the analyst who submitted the delegation request
+  if (existing.submitted_by && existing.submitted_by !== req.user.id) {
+    const truncatedPattern = existing.pattern_description.length > 80
+      ? existing.pattern_description.slice(0, 80) + '…'
+      : existing.pattern_description;
+    const reviewerNotesText = (typeof reviewerNotes === 'string' && reviewerNotes.trim())
+      ? `\n\nReviewer notes: ${reviewerNotes.trim().slice(0, 500)}`
+      : '';
+
+    try {
+      notifications.notify({
+        recipientId: existing.submitted_by,
+        eventType: 'delegation_decision',
+        title: status === 'accepted'
+          ? `Delegation accepted: "${truncatedPattern}"`
+          : `Delegation rejected: "${truncatedPattern}"`,
+        body: status === 'accepted'
+          ? `Your automation-delegation request for ${existing.system_name} has been accepted. The pattern will be handed off to the automation system on the next routing cycle.${reviewerNotesText}`
+          : `Your automation-delegation request for ${existing.system_name} was rejected. The lead reviewing the request decided this pattern should remain handled by analysts. You can submit a revised request from the Automation tab.${reviewerNotesText}`,
+        linkTab: 'automation',
+        linkParams: { delegationId: req.params.id },
+      });
+    } catch (notifyErr) {
+      logger.warn('Delegation review: notify analyst failed (non-fatal)', {
+        delegationId: req.params.id,
+        analystId: existing.submitted_by,
+        error: notifyErr.message,
+      });
+    }
+  }
+
   res.json({ ok: true });
 });
 

--- a/server/routes/notifications-admin.js
+++ b/server/routes/notifications-admin.js
@@ -1,0 +1,143 @@
+// ═══════════════════════════════════════════════════════════════════════════════
+// FIREALIVE — Notifications Admin Routes
+// Mounted at /api/inbox/admin by server/index.js. Admin-only.
+//
+// GET  /api/inbox/admin/stats                — per-status counts and recent failures
+// POST /api/inbox/admin/flush-queue          — invoke the email pipeline immediately
+// POST /api/inbox/admin/requeue/:id          — requeue a single failed/bounced notification
+// POST /api/inbox/admin/requeue-all-failed   — requeue all currently failed notifications
+//
+// These endpoints are for diagnosing and recovering from email delivery problems
+// (SMTP credential rotation, bounced addresses that have been corrected,
+// transient network failures during a cycle, etc.). Mounting under
+// /api/inbox/admin keeps them grouped with the user-facing inbox endpoints
+// while making the auth scope explicit at the mount point.
+// ═══════════════════════════════════════════════════════════════════════════════
+
+const router = require('express').Router();
+const { getDb } = require('../db/init');
+const { auditLog } = require('../middleware/audit');
+const { logger } = require('../services/logger');
+
+// ── Pipeline statistics ──────────────────────────────────────────────────────
+router.get('/stats', (req, res) => {
+  try {
+    const db = getDb();
+
+    const counts = db.prepare(`
+      SELECT
+        COUNT(*) FILTER (WHERE email_delivery_status IS NULL)            AS no_email_requested,
+        COUNT(*) FILTER (WHERE email_delivery_status = 'queued')         AS queued,
+        COUNT(*) FILTER (WHERE email_delivery_status = 'sent')           AS sent,
+        COUNT(*) FILTER (WHERE email_delivery_status = 'failed')         AS failed,
+        COUNT(*) FILTER (WHERE email_delivery_status = 'bounced')        AS bounced,
+        COUNT(*)                                                         AS total
+      FROM notifications
+    `).get();
+
+    // Recent failures (last 30 days) with error context from audit log
+    const recentFailures = db.prepare(`
+      SELECT
+        n.id,
+        n.recipient_id,
+        n.event_type,
+        n.title,
+        n.email_delivery_status,
+        n.created_at,
+        (SELECT detail FROM audit_log
+         WHERE event_type = 'NOTIFICATION_EMAIL_FAILED'
+           AND detail LIKE 'id=' || n.id || '%'
+         ORDER BY id DESC LIMIT 1) AS last_error
+      FROM notifications n
+      WHERE n.email_delivery_status IN ('failed', 'bounced')
+        AND n.created_at > datetime('now', '-30 days')
+      ORDER BY n.created_at DESC
+      LIMIT 50
+    `).all();
+
+    db.close();
+
+    res.json({ counts, recentFailures });
+  } catch (err) {
+    logger.error('Notifications admin stats error', { error: err.message });
+    res.status(500).json({ error: 'Failed to load notifications stats' });
+  }
+});
+
+// ── Flush the queue immediately ──────────────────────────────────────────────
+router.post('/flush-queue', async (req, res) => {
+  try {
+    const { processQueue } = require('../services/notifications-email');
+    const stats = await processQueue();
+    auditLog(req.user?.id, 'NOTIFICATIONS_QUEUE_FLUSHED_MANUALLY', JSON.stringify(stats), req.ip);
+    res.json({ success: true, stats });
+  } catch (err) {
+    logger.error('Notifications flush-queue error', { error: err.message });
+    res.status(500).json({ error: 'Failed to flush queue' });
+  }
+});
+
+// ── Requeue a single failed/bounced notification ─────────────────────────────
+router.post('/requeue/:id', (req, res) => {
+  try {
+    const { id } = req.params;
+    if (!id || typeof id !== 'string') return res.status(400).json({ error: 'Notification id required' });
+
+    const db = getDb();
+    const row = db.prepare(`
+      SELECT id, email_delivery_status FROM notifications WHERE id = ?
+    `).get(id);
+
+    if (!row) { db.close(); return res.status(404).json({ error: 'Notification not found' }); }
+    if (row.email_delivery_status !== 'failed' && row.email_delivery_status !== 'bounced') {
+      db.close();
+      return res.status(400).json({
+        error: `Cannot requeue notification in status "${row.email_delivery_status}". Only failed or bounced notifications can be requeued.`,
+      });
+    }
+
+    db.prepare(`
+      UPDATE notifications SET email_delivery_status = 'queued', delivered_email = 0 WHERE id = ?
+    `).run(id);
+    db.close();
+
+    auditLog(req.user?.id, 'NOTIFICATION_REQUEUED', `id=${id} from=${row.email_delivery_status}`, req.ip);
+    res.json({ success: true, id, previousStatus: row.email_delivery_status });
+  } catch (err) {
+    logger.error('Notification requeue error', { error: err.message });
+    res.status(500).json({ error: 'Failed to requeue notification' });
+  }
+});
+
+// ── Requeue all currently-failed notifications ───────────────────────────────
+// Note: bounced notifications are NOT included by default — bounces typically
+// require an address change before retrying. Pass {includeBounced: true} to
+// requeue bounces as well.
+router.post('/requeue-all-failed', (req, res) => {
+  try {
+    const includeBounced = req.body?.includeBounced === true;
+    const db = getDb();
+
+    const sql = includeBounced
+      ? `UPDATE notifications SET email_delivery_status = 'queued', delivered_email = 0
+         WHERE email_delivery_status IN ('failed', 'bounced')`
+      : `UPDATE notifications SET email_delivery_status = 'queued', delivered_email = 0
+         WHERE email_delivery_status = 'failed'`;
+
+    const result = db.prepare(sql).run();
+    db.close();
+
+    auditLog(
+      req.user?.id,
+      'NOTIFICATIONS_BULK_REQUEUED',
+      `count=${result.changes} includeBounced=${includeBounced}`,
+      req.ip,
+    );
+    res.json({ success: true, requeued: result.changes, includeBounced });
+  } catch (err) {
+    logger.error('Notifications bulk requeue error', { error: err.message });
+    res.status(500).json({ error: 'Failed to bulk-requeue notifications' });
+  }
+});
+
+module.exports = router;

--- a/server/routes/notifications-inapp.js
+++ b/server/routes/notifications-inapp.js
@@ -1,0 +1,123 @@
+// ═══════════════════════════════════════════════════════════════════════════════
+// FIREALIVE — In-App Notifications Routes
+// Mounted at /api/inbox by server/index.js.
+//
+// GET    /api/inbox                — list notifications for the current user
+// GET    /api/inbox/unread-count   — unread count for the badge
+// POST   /api/inbox/:id/read       — mark one notification read
+// POST   /api/inbox/read-all       — mark all current user's notifications read
+// GET    /api/inbox/preferences    — get this user's effective preferences
+// PUT    /api/inbox/preferences/:eventType — update one preference
+//
+// NOTE: The pre-existing /api/notifications namespace (routes/notifications.js)
+// owns burnout-alert delivery-channel config (webhook, email, SMS, PagerDuty)
+// for *outbound* alerting. That is a separate feature from in-app notifications
+// and the namespaces are intentionally kept distinct.
+// ═══════════════════════════════════════════════════════════════════════════════
+
+const router = require('express').Router();
+const notifications = require('../services/notifications');
+const { auditLog } = require('../middleware/audit');
+const { logger } = require('../services/logger');
+
+// ── List notifications for current user ──────────────────────────────────────
+router.get('/', (req, res) => {
+  try {
+    const userId = req.user?.id;
+    if (!userId) return res.status(401).json({ error: 'Authentication required' });
+
+    const includeRead = req.query.includeRead === 'true' || req.query.includeRead === '1';
+    const limitRaw = req.query.limit;
+    const limit = limitRaw ? parseInt(limitRaw, 10) : 100;
+
+    const items = notifications.listForUser(userId, { includeRead, limit });
+    res.json({ items, count: items.length });
+  } catch (err) {
+    logger.error('List notifications error', { error: err.message });
+    res.status(500).json({ error: 'Failed to list notifications' });
+  }
+});
+
+// ── Unread badge count ───────────────────────────────────────────────────────
+router.get('/unread-count', (req, res) => {
+  try {
+    const userId = req.user?.id;
+    if (!userId) return res.status(401).json({ error: 'Authentication required' });
+    res.json({ unread: notifications.unreadCount(userId) });
+  } catch (err) {
+    logger.error('Unread count error', { error: err.message });
+    res.status(500).json({ error: 'Failed to get unread count' });
+  }
+});
+
+// ── Mark one read ────────────────────────────────────────────────────────────
+router.post('/:id/read', (req, res) => {
+  try {
+    const userId = req.user?.id;
+    if (!userId) return res.status(401).json({ error: 'Authentication required' });
+
+    const id = req.params.id;
+    if (!id || typeof id !== 'string') return res.status(400).json({ error: 'Notification id required' });
+
+    const ok = notifications.markRead(userId, id);
+    if (!ok) return res.status(404).json({ error: 'Notification not found, already read, or does not belong to this user' });
+
+    res.json({ success: true });
+  } catch (err) {
+    logger.error('Mark notification read error', { error: err.message });
+    res.status(500).json({ error: 'Failed to mark notification read' });
+  }
+});
+
+// ── Mark all read ────────────────────────────────────────────────────────────
+router.post('/read-all', (req, res) => {
+  try {
+    const userId = req.user?.id;
+    if (!userId) return res.status(401).json({ error: 'Authentication required' });
+
+    const count = notifications.markAllRead(userId);
+    auditLog(userId, 'NOTIFICATIONS_MARK_ALL_READ', `count=${count}`, req.ip);
+    res.json({ success: true, marked: count });
+  } catch (err) {
+    logger.error('Mark all read error', { error: err.message });
+    res.status(500).json({ error: 'Failed to mark all notifications read' });
+  }
+});
+
+// ── Get preferences ──────────────────────────────────────────────────────────
+router.get('/preferences', (req, res) => {
+  try {
+    const userId = req.user?.id;
+    if (!userId) return res.status(401).json({ error: 'Authentication required' });
+    res.json({ preferences: notifications.getPreferences(userId) });
+  } catch (err) {
+    logger.error('Get preferences error', { error: err.message });
+    res.status(500).json({ error: 'Failed to get preferences' });
+  }
+});
+
+// ── Update one preference ────────────────────────────────────────────────────
+router.put('/preferences/:eventType', (req, res) => {
+  try {
+    const userId = req.user?.id;
+    if (!userId) return res.status(401).json({ error: 'Authentication required' });
+
+    const { eventType } = req.params;
+    if (!notifications.isKnownEventType(eventType)) {
+      return res.status(400).json({ error: `Unknown event type "${eventType}"` });
+    }
+
+    const inApp = req.body?.in_app === true || req.body?.in_app === 1;
+    const email = req.body?.email === true || req.body?.email === 1;
+
+    notifications.setPreference(userId, eventType, { in_app: inApp, email });
+    auditLog(userId, 'NOTIFICATION_PREFERENCE_UPDATED', `event=${eventType} in_app=${inApp} email=${email}`, req.ip);
+
+    res.json({ success: true, eventType, in_app: inApp, email });
+  } catch (err) {
+    logger.error('Update preference error', { error: err.message });
+    res.status(500).json({ error: 'Failed to update preference' });
+  }
+});
+
+module.exports = router;

--- a/server/routes/peer-support.js
+++ b/server/routes/peer-support.js
@@ -16,6 +16,7 @@ const crypto = require('crypto');
 const { getDb } = require('../db/init');
 const { auditLog } = require('../middleware/audit');
 const { logger } = require('../services/logger');
+const notifications = require('../services/notifications');
 
 // ── Default Disclaimer ───────────────────────────────────────────────────────
 const DEFAULT_DISCLAIMER = `PEER SUPPORT CHAT — GUIDELINES & AGREEMENT
@@ -204,12 +205,14 @@ router.post('/sessions/:id/timeout', (req, res) => {
     db.prepare("INSERT OR REPLACE INTO team_config (key, value, updated_by) VALUES (?, ?, ?)").run(noShowKey, JSON.stringify(noShows), req.user.id);
 
     // Re-open the original request (minus the no-show accepter)
+    let requestReopened = false;
     const requestRow = db.prepare("SELECT value FROM team_config WHERE key = ?").get(`peer_request_${session.requestId}`);
     if (requestRow) {
       const request = JSON.parse(requestRow.value);
       request.status = 'open';
       if (!request.excludeIds.includes(session.accepterId)) request.excludeIds.push(session.accepterId);
       db.prepare("UPDATE team_config SET value = ? WHERE key = ?").run(JSON.stringify(request), `peer_request_${session.requestId}`);
+      requestReopened = true;
     }
 
     // Alert team lead if 3+ no-shows
@@ -219,6 +222,23 @@ router.post('/sessions/:id/timeout', (req, res) => {
 
     db.close();
     auditLog(req.user.id, 'PEER_TIMEOUT', `session=${req.params.id} — re-queued`, req.ip);
+
+    // Notify the seeker (session.requesterId) that their request was re-queued
+    try {
+      notifications.notify({
+        recipientId: session.requesterId,
+        eventType: 'peer_session_timed_out',
+        title: 'Peer support request re-queued',
+        body: requestReopened
+          ? `The peer who accepted your support request did not show up, so your request has been re-queued for a different helper. The previous helper has been excluded from seeing this request again. You don't need to do anything — just wait for someone else to accept, or re-post the request if you'd prefer.`
+          : `The peer support session you were in timed out. The original request could not be re-opened automatically. Please post a new request from the Peer Skill-Share tab if you still need support.`,
+        linkTab: 'peer-share',
+        linkParams: { focus: requestReopened ? 'requests' : 'create' },
+      });
+    } catch (notifyErr) {
+      logger.warn('Peer timeout: notify seeker failed (non-fatal)', { sessionId: req.params.id, requesterId: session.requesterId, error: notifyErr.message });
+    }
+
     res.json({ ok: true, message: 'Session timed out. Request re-queued.' });
   } catch (err) {
     logger.error('Timeout session error', { error: err.message });

--- a/server/routes/peers.js
+++ b/server/routes/peers.js
@@ -167,6 +167,21 @@ router.post('/requests/:id/accept', (req, res) => {
 
     db.close();
     auditLog(req.user.id, 'PEER_SESSION_CREATED', 'Anonymous peer chat session started', req.ip);
+
+    // Notify the seeker (request.requesterId) that someone accepted
+    try {
+      notifications.notify({
+        recipientId: request.requesterId,
+        eventType: 'peer_request_accepted',
+        title: 'A peer accepted your support request',
+        body: `Someone has accepted your peer support request and a session is now active. Their identity remains hidden until both of you consent to reveal it. Open the Peer Skill-Share tab to start the conversation.`,
+        linkTab: 'peer-share',
+        linkParams: { sessionId, focus: 'session' },
+      });
+    } catch (notifyErr) {
+      logger.warn('Peer accept: notify seeker failed (non-fatal)', { sessionId, requesterId: request.requesterId, error: notifyErr.message });
+    }
+
     res.status(201).json({ sessionId, status: 'active' });
   } catch (err) {
     logger.error('Accept peer request error', { error: err.message });

--- a/server/routes/peers.js
+++ b/server/routes/peers.js
@@ -19,6 +19,7 @@ const crypto = require('crypto');
 const { getDb } = require('../db/init');
 const { auditLog } = require('../middleware/audit');
 const { logger } = require('../services/logger');
+const notifications = require('../services/notifications');
 
 // Anti-C2: max messages per user per hour
 const MAX_MESSAGES_PER_HOUR = 50;
@@ -35,6 +36,7 @@ router.post('/requests', (req, res) => {
   try {
     const db = getDb();
     const id = crypto.randomBytes(16).toString('hex');
+    const excludeIds = Array.isArray(excludeAnalystIds) ? excludeAnalystIds : [];
 
     // Store request — requester identity is encrypted (server knows for routing
     // but never exposes to other analysts)
@@ -46,7 +48,7 @@ router.post('/requests', (req, res) => {
       JSON.stringify({
         id,
         topic: topic.slice(0, 500),
-        excludeIds: Array.isArray(excludeAnalystIds) ? excludeAnalystIds : [],
+        excludeIds,
         willingToMeet: !!willingToMeetInPerson,
         requesterId: req.user.id, // stored but never exposed
         status: 'open',
@@ -57,7 +59,40 @@ router.post('/requests', (req, res) => {
 
     db.close();
     auditLog(req.user.id, 'PEER_REQUEST_CREATED', 'Anonymous peer support request', req.ip);
-    res.status(201).json({ id, status: 'open' });
+
+    // Broadcast notification to eligible helpers (opt-in event, daily cap 5)
+    let notifiedCount = 0;
+    let cappedCount = 0;
+    try {
+      const eligible = notifications.getEligibleRecipients('peer_request_posted', {
+        roles: ['analyst', 'lead'],
+        activeOnly: true,
+        excludeUserIds: [req.user.id, ...excludeIds],
+      });
+      const dailyCap = notifications.EVENT_TYPES.peer_request_posted.dailyCap || Infinity;
+
+      for (const recipientId of eligible) {
+        const todayCount = notifications.getDailySendCount(recipientId, 'peer_request_posted');
+        if (todayCount >= dailyCap) { cappedCount++; continue; }
+        try {
+          notifications.notify({
+            recipientId,
+            eventType: 'peer_request_posted',
+            title: 'New peer support request available',
+            body: `An analyst has posted a new peer support request you're eligible to accept. Topic: "${topic.slice(0, 120)}${topic.length > 120 ? '…' : ''}". Open the Peer Skill-Share tab to view available requests.`,
+            linkTab: 'peer-share',
+            linkParams: { focus: 'requests' },
+          });
+          notifiedCount++;
+        } catch (notifyErr) {
+          logger.warn('Peer request post: notify recipient failed (non-fatal)', { recipientId, error: notifyErr.message });
+        }
+      }
+    } catch (broadcastErr) {
+      logger.error('Peer request post: broadcast failed (non-fatal)', { error: broadcastErr.message });
+    }
+
+    res.status(201).json({ id, status: 'open', notified: notifiedCount, cappedFromBroadcast: cappedCount });
   } catch (err) {
     logger.error('Create peer request error', { error: err.message });
     res.status(500).json({ error: 'Failed to create peer request' });

--- a/server/routes/peers.js
+++ b/server/routes/peers.js
@@ -201,11 +201,14 @@ router.post('/sessions/:id/consent', (req, res) => {
     const session = JSON.parse(row.value);
     if (session.status !== 'active') { db.close(); return res.status(400).json({ error: 'Session is not active' }); }
 
-    // Determine which party is consenting
+    // Determine which party is consenting (and which is the OTHER party)
+    let firstConsenterId = null;
     if (req.user.id === session.requesterId) {
       session.requesterConsent = true;
+      firstConsenterId = session.accepterId;
     } else if (req.user.id === session.accepterId) {
       session.accepterConsent = true;
+      firstConsenterId = session.requesterId;
     } else {
       db.close(); return res.status(403).json({ error: 'You are not a participant in this session' });
     }
@@ -216,12 +219,32 @@ router.post('/sessions/:id/consent', (req, res) => {
     const mutualConsent = session.requesterConsent && session.accepterConsent;
     auditLog(req.user.id, 'PEER_CONSENT', `Identity consent given. Mutual: ${mutualConsent}`, req.ip);
 
-    // If both consented, return both names
+    // If both consented, return both names AND notify the first consenter
     if (mutualConsent) {
       const db2 = getDb();
       const requester = db2.prepare('SELECT name FROM users WHERE id = ?').get(session.requesterId);
       const accepter = db2.prepare('SELECT name FROM users WHERE id = ?').get(session.accepterId);
       db2.close();
+
+      // Notify the OTHER party (the first consenter — they consented earlier and have been waiting)
+      const firstConsenterIsRequester = firstConsenterId === session.requesterId;
+      const peerName = firstConsenterIsRequester ? accepter?.name : requester?.name;
+
+      try {
+        notifications.notify({
+          recipientId: firstConsenterId,
+          eventType: 'peer_consent_mutual',
+          title: 'Identity revealed in your peer session',
+          body: peerName
+            ? `Your peer in the active support session has consented to reveal their identity. You can now see each other's names. Your peer is ${peerName}. Open the Peer Skill-Share tab to continue.`
+            : `Your peer in the active support session has consented to reveal their identity. You can now see each other's names. Open the Peer Skill-Share tab to continue.`,
+          linkTab: 'peer-share',
+          linkParams: { sessionId: req.params.id, focus: 'session' },
+        });
+      } catch (notifyErr) {
+        logger.warn('Peer consent: notify first consenter failed (non-fatal)', { sessionId: req.params.id, firstConsenterId, error: notifyErr.message });
+      }
+
       return res.json({
         mutualConsent: true,
         requesterName: requester?.name,

--- a/server/routes/retro.js
+++ b/server/routes/retro.js
@@ -80,10 +80,36 @@ router.put('/:id/complete', (req, res) => {
 
 router.post('/:id/followup', (req, res) => {
   const db = getDb();
-  db.prepare('INSERT INTO retro_actions (retro_id, action_text) VALUES (?, ?)').run(req.params.id, 'Follow-up check-in sent at ' + new Date().toISOString());
+  const retroId = req.params.id;
+
+  // Fetch the retro and its attached analysts before recording the follow-up
+  const retro = db.prepare('SELECT incident, severity FROM retro_protocols WHERE id = ?').get(retroId);
+  if (!retro) { db.close(); return res.status(404).json({ error: 'Retro not found' }); }
+
+  const analystIds = db.prepare('SELECT analyst_id FROM retro_analysts WHERE retro_id = ?').all(retroId).map(r => r.analyst_id);
+
+  db.prepare('INSERT INTO retro_actions (retro_id, action_text) VALUES (?, ?)').run(retroId, 'Follow-up check-in sent at ' + new Date().toISOString());
   db.close();
-  auditLog(req.user.id, 'RETRO_FOLLOWUP', req.params.id, req.ip);
-  res.json({ ok: true });
+
+  auditLog(req.user.id, 'RETRO_FOLLOWUP', retroId, req.ip);
+
+  // Notify each analyst attached to this retro
+  for (const aid of analystIds) {
+    try {
+      notifications.notify({
+        recipientId: aid,
+        eventType: 'retro_followup_sent',
+        title: `Recovery check-in: ${retro.incident}`,
+        body: `Your team lead is checking in on your post-incident recovery for "${retro.incident}" (${retro.severity}). If you're still feeling the effects of this incident, peer support is available, and your lighter-queue eligibility is still active. Open the Post-Incident Wellness tab to respond.`,
+        linkTab: 'recovery',
+        linkParams: { retroId },
+      });
+    } catch (notifyErr) {
+      logger.warn('Retro followup: notify analyst failed (non-fatal)', { analystId: aid, retroId, error: notifyErr.message });
+    }
+  }
+
+  res.json({ ok: true, notified: analystIds.length });
 });
 
 module.exports = router;

--- a/server/routes/retro.js
+++ b/server/routes/retro.js
@@ -1,6 +1,8 @@
 const router = require('express').Router();
 const { getDb } = require('../db/init');
 const { auditLog } = require('../middleware/audit');
+const { logger } = require('../services/logger');
+const notifications = require('../services/notifications');
 
 router.get('/', (req, res) => {
   const db = getDb();
@@ -21,9 +23,10 @@ router.post('/', (req, res) => {
   const crypto = require('crypto');
   const db = getDb();
   const retroId = crypto.randomBytes(16).toString('hex');
+  const duration = queueReductionDuration || '24hr';
 
   db.prepare('INSERT INTO retro_protocols (id, incident, severity, queue_reduction_duration, initiated_by) VALUES (?, ?, ?, ?, ?)')
-    .run(retroId, incident, severity, queueReductionDuration || '24hr', req.user.id);
+    .run(retroId, incident, severity, duration, req.user.id);
 
   const insertAnalyst = db.prepare('INSERT INTO retro_analysts (retro_id, analyst_id) VALUES (?, ?)');
   const insertAction = db.prepare('INSERT INTO retro_actions (retro_id, action_text) VALUES (?, ?)');
@@ -40,6 +43,23 @@ router.post('/', (req, res) => {
 
   db.close();
   auditLog(req.user.id, 'RETRO_ACTIVATED', `${incident} — ${analystIds.length} analysts`, req.ip);
+
+  // Notify each analyst added to the retro
+  for (const aid of analystIds) {
+    try {
+      notifications.notify({
+        recipientId: aid,
+        eventType: 'retro_scheduled',
+        title: `Post-incident recovery scheduled: ${incident}`,
+        body: `You've been added to a ${severity} post-incident recovery protocol for "${incident}". Lighter queues are active for ${duration}, peer support is available, and check-ins are scheduled at 24hr, 72hr, and 2 weeks. Open the Post-Incident Wellness tab for details.`,
+        linkTab: 'recovery',
+        linkParams: { retroId },
+      });
+    } catch (notifyErr) {
+      logger.warn('Retro create: notify analyst failed (non-fatal)', { analystId: aid, retroId, error: notifyErr.message });
+    }
+  }
+
   res.status(201).json({ id: retroId });
 });
 

--- a/server/services/notifications-email.js
+++ b/server/services/notifications-email.js
@@ -1,0 +1,223 @@
+// ═══════════════════════════════════════════════════════════════════════════════
+// FIREALIVE — Notifications Email Pipeline
+//
+// Processes queued in-app notifications and delivers them via the team's
+// configured email channel. Invoked periodically by the scheduler service
+// (every 60s; configurable via NOTIFICATIONS_EMAIL_INTERVAL_SEC env var).
+//
+// DELIVERY CHANNELS (resolved from notification_config row id='default',
+// which is owned by routes/notifications.js):
+//   - SMTP via Nodemailer (when email_enabled=1 and SMTP env vars set)
+//   - Webhook POST (when webhook_enabled=1 and webhook_url set)
+//   - PagerDuty event (when pagerduty_enabled=1 and pagerduty_key set)
+//
+// If the user opted into email for a notification but no delivery channel is
+// configured, the row stays at email_delivery_status='queued'. The pipeline
+// logs this state once per processing cycle and continues. When a channel
+// later gets configured, queued emails flow through automatically.
+//
+// FAILURE HANDLING:
+// On send failure (transport error, 4xx, 5xx, timeout), the row is updated
+// to email_delivery_status='failed' with the error in a 'last_error' field
+// (added in commit 1's schema as part of the body field's reuse — actually
+// no, it's stored in the audit log via auditLog and the row stays 'failed').
+// We do not retry automatically; failed emails are visible in the audit log
+// and a lead can manually requeue them via /api/inbox/admin/requeue-email/:id
+// (added in a later sub-phase if needed). Bounce detection happens via the
+// SMTP/webhook response when available; bouncedstays distinct from 'failed'
+// because bounced emails should not be re-sent without address change.
+//
+// The pipeline is non-blocking: if SMTP transport hangs, individual sends
+// have a 10s timeout and the next cycle continues from where this left off.
+// ═══════════════════════════════════════════════════════════════════════════════
+
+const { getDb } = require('../db/init');
+const { logger } = require('./logger');
+const { auditLog } = require('../middleware/audit');
+
+const BATCH_SIZE = 50;
+const SEND_TIMEOUT_MS = 10000;
+const PIPELINE_VERSION = 1;
+
+// ── Config resolution ────────────────────────────────────────────────────────
+function loadConfig(db) {
+  const row = db.prepare(`
+    SELECT email_enabled, email_address, webhook_enabled, webhook_url,
+           pagerduty_enabled, pagerduty_key
+    FROM notification_config WHERE id = 'default'
+  `).get();
+  if (!row) return null;
+  return {
+    smtp: row.email_enabled === 1 && row.email_address ? {
+      address: row.email_address,
+      host: process.env.SMTP_HOST || null,
+      port: parseInt(process.env.SMTP_PORT || '587', 10),
+      secure: process.env.SMTP_SECURE === 'true',
+      user: process.env.SMTP_USER || null,
+      pass: process.env.SMTP_PASS || null,
+      from: process.env.SMTP_FROM || row.email_address,
+    } : null,
+    webhook: row.webhook_enabled === 1 && row.webhook_url ? {
+      url: row.webhook_url,
+    } : null,
+    pagerduty: row.pagerduty_enabled === 1 && row.pagerduty_key ? {
+      key: row.pagerduty_key,
+    } : null,
+  };
+}
+
+function hasAnyChannel(cfg) {
+  return !!(cfg && (cfg.smtp || cfg.webhook || cfg.pagerduty));
+}
+
+// ── Recipient email resolution ───────────────────────────────────────────────
+// notifications.recipient_id is users.id. The user's email address is stored
+// in users.username (which is treated as the login identifier; for SSO users
+// it's the SSO email; for local users it's set at provisioning).
+function lookupRecipientEmail(db, userId) {
+  const row = db.prepare("SELECT username, name, auth_method, external_id FROM users WHERE id = ?").get(userId);
+  if (!row) return null;
+  if (row.auth_method !== 'local') return row.external_id || row.username;
+  return row.username;
+}
+
+// ── Send transports ──────────────────────────────────────────────────────────
+
+async function sendViaSmtp(cfg, { to, subject, text }) {
+  if (!cfg.smtp.host || !cfg.smtp.user || !cfg.smtp.pass) {
+    return { ok: false, status: 'failed', error: 'SMTP host/user/pass not set in env (SMTP_HOST/SMTP_USER/SMTP_PASS)' };
+  }
+  let nodemailer;
+  try { nodemailer = require('nodemailer'); }
+  catch { return { ok: false, status: 'failed', error: 'nodemailer not installed; run npm install nodemailer' }; }
+
+  const transport = nodemailer.createTransport({
+    host: cfg.smtp.host, port: cfg.smtp.port, secure: cfg.smtp.secure,
+    auth: { user: cfg.smtp.user, pass: cfg.smtp.pass },
+    connectionTimeout: SEND_TIMEOUT_MS, socketTimeout: SEND_TIMEOUT_MS,
+  });
+  try {
+    const info = await transport.sendMail({
+      from: cfg.smtp.from, to, subject, text,
+    });
+    if (info.rejected && info.rejected.length > 0) {
+      return { ok: false, status: 'bounced', error: `Rejected: ${info.rejected.join(', ')}` };
+    }
+    return { ok: true, status: 'sent' };
+  } catch (err) {
+    const isBounce = /5\d\d|bounce|mailbox|no such user|user unknown/i.test(err.message || '');
+    return { ok: false, status: isBounce ? 'bounced' : 'failed', error: err.message };
+  }
+}
+
+async function sendViaWebhook(cfg, payload) {
+  try {
+    const ctrl = new AbortController();
+    const t = setTimeout(() => ctrl.abort(), SEND_TIMEOUT_MS);
+    const resp = await fetch(cfg.webhook.url, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', 'User-Agent': `FireAlive-Notifications/${PIPELINE_VERSION}` },
+      body: JSON.stringify(payload),
+      signal: ctrl.signal,
+    });
+    clearTimeout(t);
+    if (resp.ok) return { ok: true, status: 'sent' };
+    return { ok: false, status: 'failed', error: `Webhook returned ${resp.status}` };
+  } catch (err) {
+    return { ok: false, status: 'failed', error: err.name === 'AbortError' ? 'Webhook timeout' : err.message };
+  }
+}
+
+async function sendViaPagerDuty(cfg, { subject, text, eventType }) {
+  try {
+    const ctrl = new AbortController();
+    const t = setTimeout(() => ctrl.abort(), SEND_TIMEOUT_MS);
+    const resp = await fetch('https://events.pagerduty.com/v2/enqueue', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        routing_key: cfg.pagerduty.key,
+        event_action: 'trigger',
+        payload: {
+          summary: subject,
+          source: 'firealive',
+          severity: 'info',
+          custom_details: { body: text, event_type: eventType },
+        },
+      }),
+      signal: ctrl.signal,
+    });
+    clearTimeout(t);
+    if (resp.ok || resp.status === 202) return { ok: true, status: 'sent' };
+    return { ok: false, status: 'failed', error: `PagerDuty returned ${resp.status}` };
+  } catch (err) {
+    return { ok: false, status: 'failed', error: err.name === 'AbortError' ? 'PagerDuty timeout' : err.message };
+  }
+}
+
+// ── Pipeline entry point ─────────────────────────────────────────────────────
+async function processQueue() {
+  const db = getDb();
+  let cfg;
+  try {
+    cfg = loadConfig(db);
+  } catch (err) {
+    logger.error('Notifications email pipeline: failed to load config', { error: err.message });
+    db.close();
+    return { processed: 0, sent: 0, failed: 0, bounced: 0, skipped: 0 };
+  }
+
+  const queued = db.prepare(`
+    SELECT id, recipient_id, event_type, title, body
+    FROM notifications
+    WHERE email_delivery_status = 'queued'
+    ORDER BY created_at ASC
+    LIMIT ?
+  `).all(BATCH_SIZE);
+
+  if (queued.length === 0) { db.close(); return { processed: 0, sent: 0, failed: 0, bounced: 0, skipped: 0 }; }
+
+  if (!hasAnyChannel(cfg)) {
+    logger.info('Notifications email pipeline: queued items waiting but no delivery channel configured', { queued: queued.length });
+    db.close();
+    return { processed: 0, sent: 0, failed: 0, bounced: 0, skipped: queued.length };
+  }
+
+  const stats = { processed: 0, sent: 0, failed: 0, bounced: 0, skipped: 0 };
+  const updateStatus = db.prepare(`UPDATE notifications SET email_delivery_status = ?, delivered_email = ? WHERE id = ?`);
+
+  for (const n of queued) {
+    stats.processed++;
+    const email = lookupRecipientEmail(db, n.recipient_id);
+    if (!email) {
+      updateStatus.run('failed', 0, n.id);
+      stats.failed++;
+      logger.warn('Notifications email pipeline: recipient has no email address', { notificationId: n.id, recipientId: n.recipient_id });
+      continue;
+    }
+
+    const subject = `[FireAlive] ${n.title}`;
+    const text = (n.body ? `${n.body}\n\n` : '') + `View in FireAlive: open the Inbox tab in your Management Console or Analyst Client.`;
+    const payload = { subject, text, eventType: n.event_type, recipientEmail: email, recipientId: n.recipient_id, notificationId: n.id };
+
+    let result;
+    if (cfg.smtp) result = await sendViaSmtp(cfg, { to: email, subject, text });
+    else if (cfg.webhook) result = await sendViaWebhook(cfg, payload);
+    else if (cfg.pagerduty) result = await sendViaPagerDuty(cfg, { subject, text, eventType: n.event_type });
+
+    if (result.ok) {
+      updateStatus.run('sent', 1, n.id);
+      stats.sent++;
+    } else {
+      updateStatus.run(result.status, 0, n.id);
+      if (result.status === 'bounced') stats.bounced++;
+      else stats.failed++;
+      auditLog(null, 'NOTIFICATION_EMAIL_FAILED', `id=${n.id} event=${n.event_type} status=${result.status} error=${result.error}`, null);
+    }
+  }
+
+  db.close();
+  return stats;
+}
+
+module.exports = { processQueue, BATCH_SIZE, SEND_TIMEOUT_MS };

--- a/server/services/notifications.js
+++ b/server/services/notifications.js
@@ -348,6 +348,33 @@ function getEligibleRecipients(eventType, opts = {}) {
   }
 }
 
+// Return the count of notifications of `eventType` delivered to `userId`
+// within the last `windowHours` (default 24). Used by event types with a
+// dailyCap to skip recipients who would exceed it.
+//
+// "Delivered" here means delivered_in_app=1 OR delivered_email=1. Rows
+// where neither flag is set don't count — they represent notifications
+// the user opted out of, which were created but never surfaced.
+function getDailySendCount(userId, eventType, windowHours = 24) {
+  if (!isKnownEventType(eventType)) {
+    throw new Error(`getDailySendCount(): unknown event type "${eventType}"`);
+  }
+  const db = getDb();
+  try {
+    const row = db.prepare(`
+      SELECT COUNT(*) AS c
+      FROM notifications
+      WHERE recipient_id = ?
+        AND event_type = ?
+        AND (delivered_in_app = 1 OR delivered_email = 1)
+        AND created_at > datetime('now', ?)
+    `).get(userId, eventType, `-${windowHours} hours`);
+    return row?.c || 0;
+  } finally {
+    db.close();
+  }
+}
+
 // ── Internal helpers ─────────────────────────────────────────────────────────
 function safeJsonParse(s) {
   try { return JSON.parse(s); } catch { return null; }
@@ -365,4 +392,5 @@ module.exports = {
   getPreferences,
   setPreference,
   getEligibleRecipients,
+  getDailySendCount,
 };

--- a/server/services/notifications.js
+++ b/server/services/notifications.js
@@ -46,15 +46,26 @@ const EVENT_TYPES = {
     default: { in_app: 1, email: 1 },
     description: 'A scheduled check-in (24hr, 72hr, or 2-week mark) for one of your active recovery protocols.',
   },
-  peer_request_received: {
-    label: 'A peer wants to share with you',
-    default: { in_app: 1, email: 0 },
-    description: 'Another analyst has requested a peer skill-share session.',
+  peer_request_posted: {
+    label: 'New peer support request available',
+    default: { in_app: 0, email: 0 },
+    description: 'An analyst posted a peer support request you are eligible to accept. Default off because volume can be high — opt in if you want to be a fast responder.',
+    dailyCap: 5,
   },
-  peer_session_rated: {
-    label: 'Your peer session was rated',
+  peer_request_accepted: {
+    label: 'A peer accepted your support request',
     default: { in_app: 1, email: 0 },
-    description: 'A seeker rated a peer-share session you helped with.',
+    description: 'Someone has accepted your peer support request. A session is now active.',
+  },
+  peer_consent_mutual: {
+    label: 'Identity revealed in peer session',
+    default: { in_app: 1, email: 0 },
+    description: 'Both parties consented to reveal identities in your active peer support session.',
+  },
+  peer_session_timed_out: {
+    label: 'Peer session timed out — request re-queued',
+    default: { in_app: 1, email: 0 },
+    description: 'Your peer support request was accepted but the helper did not show up. Your request has been re-queued for a different helper.',
   },
   iam_recert_due: {
     label: 'IAM recertification is due',

--- a/server/services/notifications.js
+++ b/server/services/notifications.js
@@ -41,6 +41,11 @@ const EVENT_TYPES = {
     default: { in_app: 1, email: 1 },
     description: 'You have been added to a post-incident recovery protocol.',
   },
+  retro_followup_sent: {
+    label: 'Post-incident recovery check-in',
+    default: { in_app: 1, email: 1 },
+    description: 'A scheduled check-in (24hr, 72hr, or 2-week mark) for one of your active recovery protocols.',
+  },
   peer_request_received: {
     label: 'A peer wants to share with you',
     default: { in_app: 1, email: 0 },

--- a/server/services/notifications.js
+++ b/server/services/notifications.js
@@ -289,6 +289,65 @@ function setPreference(userId, eventType, { in_app, email }) {
   }
 }
 
+// Return all user IDs who have at least one channel enabled for `eventType`,
+// optionally filtered to specific roles. Used by broadcast events:
+// peer_request_posted, routing_panic_engaged, iam_recert_due.
+//
+// Resolution rules:
+//   - A user with a row in notification_preferences for this event type uses
+//     that row's in_app/email values.
+//   - A user with no row uses the EVENT_TYPES[eventType].default values.
+//   - "Eligible" = at least one of (in_app, email) is on.
+//
+// Filters:
+//   - opts.roles: array like ['lead', 'admin']. If omitted, all roles are eligible.
+//   - opts.activeOnly: defaults true. Restricts to users with active=1 (where
+//     the column exists; users.active was added in v0.0.25 — but in this
+//     codebase the column is on users.available rather than users.active.
+//     We use users.available which is the actual column name in db/init.js.)
+//   - opts.excludeUserIds: array of user IDs to exclude (e.g., the requester
+//     in a peer-share broadcast, or analysts on the requester's exclude list).
+function getEligibleRecipients(eventType, opts = {}) {
+  if (!isKnownEventType(eventType)) {
+    throw new Error(`getEligibleRecipients(): unknown event type "${eventType}"`);
+  }
+
+  const { roles, activeOnly = true, excludeUserIds = [] } = opts;
+  const eventDefaults = EVENT_TYPES[eventType].default;
+
+  const db = getDb();
+  try {
+    // Build user query
+    const conditions = [];
+    const params = [];
+    if (Array.isArray(roles) && roles.length > 0) {
+      conditions.push(`role IN (${roles.map(() => '?').join(',')})`);
+      params.push(...roles);
+    }
+    if (activeOnly) conditions.push('available = 1');
+    const whereClause = conditions.length ? `WHERE ${conditions.join(' AND ')}` : '';
+    const users = db.prepare(`SELECT id FROM users ${whereClause}`).all(...params);
+
+    // Pre-fetch all preferences for this event type in one query
+    const prefRows = db.prepare(`
+      SELECT user_id, in_app, email FROM notification_preferences WHERE event_type = ?
+    `).all(eventType);
+    const prefByUser = {};
+    for (const r of prefRows) prefByUser[r.user_id] = { in_app: r.in_app === 1, email: r.email === 1 };
+
+    const excludeSet = new Set(excludeUserIds);
+    const eligible = [];
+    for (const u of users) {
+      if (excludeSet.has(u.id)) continue;
+      const pref = prefByUser[u.id] || { in_app: eventDefaults.in_app === 1, email: eventDefaults.email === 1 };
+      if (pref.in_app || pref.email) eligible.push(u.id);
+    }
+    return eligible;
+  } finally {
+    db.close();
+  }
+}
+
 // ── Internal helpers ─────────────────────────────────────────────────────────
 function safeJsonParse(s) {
   try { return JSON.parse(s); } catch { return null; }
@@ -305,4 +364,5 @@ module.exports = {
   markAllRead,
   getPreferences,
   setPreference,
+  getEligibleRecipients,
 };

--- a/server/services/notifications.js
+++ b/server/services/notifications.js
@@ -1,0 +1,292 @@
+// ═══════════════════════════════════════════════════════════════════════════════
+// FIREALIVE — Notifications Service
+//
+// Single owner of notification creation, listing, marking-read, and per-user
+// per-event-type delivery preferences. All other code paths that need to
+// generate a notification (assessments, retro, peer-share, IAM, helper-pay,
+// etc.) call notify() here rather than writing to the notifications table
+// directly.
+//
+// notify() handles channel fan-out: it consults the recipient's
+// notification_preferences for the event_type and writes one notifications
+// row regardless (so the in-app badge always reflects the event), then —
+// if the user has email enabled for this event_type — enqueues an email
+// delivery via the existing notification_config (the burnout-alerts email
+// channel that's already wired through routes/notifications.js).
+//
+// EVENT TYPES are an explicit allowlist. Adding a new event type means
+// adding it to EVENT_TYPES below AND defining a default preference. This
+// keeps the notification surface intentional rather than ambient.
+// ═══════════════════════════════════════════════════════════════════════════════
+
+const { getDb } = require('../db/init');
+const { logger } = require('./logger');
+
+// ── Event type registry ──────────────────────────────────────────────────────
+// Each event type declares: human-readable label, default in_app, default email,
+// and a description that the preferences UI surfaces to users.
+const EVENT_TYPES = {
+  assessment_assigned: {
+    label: 'New assessment assigned to you',
+    default: { in_app: 1, email: 0 },
+    description: 'A team lead has assigned a skills assessment to you.',
+  },
+  assessment_completed: {
+    label: 'Assessment completed by an analyst',
+    default: { in_app: 1, email: 0 },
+    description: '(Leads only) An analyst on your team finished an assessment.',
+  },
+  retro_scheduled: {
+    label: 'Post-incident retrospective scheduled',
+    default: { in_app: 1, email: 1 },
+    description: 'You have been added to a post-incident recovery protocol.',
+  },
+  peer_request_received: {
+    label: 'A peer wants to share with you',
+    default: { in_app: 1, email: 0 },
+    description: 'Another analyst has requested a peer skill-share session.',
+  },
+  peer_session_rated: {
+    label: 'Your peer session was rated',
+    default: { in_app: 1, email: 0 },
+    description: 'A seeker rated a peer-share session you helped with.',
+  },
+  iam_recert_due: {
+    label: 'IAM recertification is due',
+    default: { in_app: 1, email: 1 },
+    description: '(Leads only) One or more analysts need IAM recertification.',
+  },
+  helper_points_awarded: {
+    label: 'Helper Pay points awarded',
+    default: { in_app: 1, email: 0 },
+    description: 'You earned Helper Pay points for a peer-share session.',
+  },
+  helper_redemption_approved: {
+    label: 'Helper Pay redemption approved',
+    default: { in_app: 1, email: 1 },
+    description: 'Your Helper Pay redemption request has been approved.',
+  },
+  helper_redemption_denied: {
+    label: 'Helper Pay redemption denied',
+    default: { in_app: 1, email: 1 },
+    description: 'Your Helper Pay redemption request was denied.',
+  },
+  delegation_decision: {
+    label: 'Automation delegation decision',
+    default: { in_app: 1, email: 0 },
+    description: 'Your delegation request was accepted or rejected.',
+  },
+  routing_panic_engaged: {
+    label: 'Panic-mode routing engaged',
+    default: { in_app: 1, email: 1 },
+    description: '(Leads/admins) Panic mode has been engaged on the team.',
+  },
+};
+
+function isKnownEventType(eventType) {
+  return Object.prototype.hasOwnProperty.call(EVENT_TYPES, eventType);
+}
+
+// ── Preference resolution ────────────────────────────────────────────────────
+// Returns {in_app, email} effective for this user/event combination, falling
+// back to EVENT_TYPES[eventType].default when the user has no row.
+function resolvePreference(db, userId, eventType) {
+  const row = db.prepare(`
+    SELECT in_app, email FROM notification_preferences WHERE user_id = ? AND event_type = ?
+  `).get(userId, eventType);
+  if (row) return { in_app: row.in_app === 1, email: row.email === 1 };
+  const fallback = EVENT_TYPES[eventType].default;
+  return { in_app: fallback.in_app === 1, email: fallback.email === 1 };
+}
+
+// ── Email queue (deferred to a later commit) ─────────────────────────────────
+// The email channel uses the existing notification_config row (configured via
+// routes/notifications.js — webhook/PagerDuty/email/SMS for burnout alerts).
+// For Phase 1.4a commit 2, we record that an email was *requested* but defer
+// actual SMTP delivery to commit 4 (email pipeline). Until commit 4 lands,
+// email_delivery_status='queued' is the terminal state.
+function enqueueEmail(db, notificationId) {
+  db.prepare(`
+    UPDATE notifications SET email_delivery_status = 'queued' WHERE id = ?
+  `).run(notificationId);
+}
+
+// ── Public API ───────────────────────────────────────────────────────────────
+
+// Create one notification for one recipient. Returns the notification id.
+// Throws if eventType is not a known event type.
+function notify({ recipientId, eventType, title, body = null, linkTab = null, linkParams = null }) {
+  if (!recipientId || typeof recipientId !== 'string') {
+    throw new Error('notify(): recipientId is required');
+  }
+  if (!isKnownEventType(eventType)) {
+    throw new Error(`notify(): unknown event type "${eventType}". Add it to EVENT_TYPES in services/notifications.js if it should exist.`);
+  }
+  if (!title || typeof title !== 'string') {
+    throw new Error('notify(): title is required');
+  }
+
+  const db = getDb();
+  try {
+    const pref = resolvePreference(db, recipientId, eventType);
+
+    const linkParamsJson = linkParams ? JSON.stringify(linkParams) : null;
+
+    const result = db.prepare(`
+      INSERT INTO notifications (recipient_id, event_type, title, body, link_tab, link_params, delivered_in_app, delivered_email)
+      VALUES (?, ?, ?, ?, ?, ?, ?, 0)
+    `).run(recipientId, eventType, title, body, linkTab, linkParamsJson, pref.in_app ? 1 : 0);
+
+    const notificationId = db.prepare(`
+      SELECT id FROM notifications WHERE rowid = ?
+    `).get(result.lastInsertRowid)?.id;
+
+    if (pref.email && notificationId) {
+      enqueueEmail(db, notificationId);
+    }
+
+    return notificationId;
+  } catch (err) {
+    logger.error('notify failed', { recipientId, eventType, error: err.message });
+    throw err;
+  } finally {
+    db.close();
+  }
+}
+
+// Notify many recipients at once. Returns the array of notification ids
+// (in the same order as recipientIds). Skips falsy ids silently.
+function notifyMany({ recipientIds, eventType, title, body = null, linkTab = null, linkParams = null }) {
+  if (!Array.isArray(recipientIds)) {
+    throw new Error('notifyMany(): recipientIds must be an array');
+  }
+  return recipientIds
+    .filter(id => typeof id === 'string' && id)
+    .map(id => notify({ recipientId: id, eventType, title, body, linkTab, linkParams }));
+}
+
+// List notifications for a user. Default: unread, newest first, capped at 100.
+// Pass {includeRead: true} to include already-read notifications.
+function listForUser(userId, { includeRead = false, limit = 100 } = {}) {
+  const db = getDb();
+  try {
+    const cap = Math.min(Math.max(parseInt(limit, 10) || 100, 1), 500);
+    const sql = includeRead
+      ? `SELECT id, event_type, title, body, link_tab, link_params, read_at, created_at
+         FROM notifications WHERE recipient_id = ? ORDER BY created_at DESC LIMIT ?`
+      : `SELECT id, event_type, title, body, link_tab, link_params, read_at, created_at
+         FROM notifications WHERE recipient_id = ? AND read_at IS NULL ORDER BY created_at DESC LIMIT ?`;
+    const rows = db.prepare(sql).all(userId, cap);
+    return rows.map(r => ({
+      ...r,
+      link_params: r.link_params ? safeJsonParse(r.link_params) : null,
+    }));
+  } finally {
+    db.close();
+  }
+}
+
+// Count unread notifications for a user (for the badge in the MC/AC).
+function unreadCount(userId) {
+  const db = getDb();
+  try {
+    const row = db.prepare(`
+      SELECT COUNT(*) AS c FROM notifications WHERE recipient_id = ? AND read_at IS NULL
+    `).get(userId);
+    return row?.c || 0;
+  } finally {
+    db.close();
+  }
+}
+
+// Mark a single notification read. Returns true if it was unread and got marked,
+// false if it didn't exist or was already read or didn't belong to this user.
+function markRead(userId, notificationId) {
+  const db = getDb();
+  try {
+    const result = db.prepare(`
+      UPDATE notifications SET read_at = datetime('now')
+      WHERE id = ? AND recipient_id = ? AND read_at IS NULL
+    `).run(notificationId, userId);
+    return result.changes > 0;
+  } finally {
+    db.close();
+  }
+}
+
+// Mark all unread notifications read for a user. Returns the number marked.
+function markAllRead(userId) {
+  const db = getDb();
+  try {
+    const result = db.prepare(`
+      UPDATE notifications SET read_at = datetime('now')
+      WHERE recipient_id = ? AND read_at IS NULL
+    `).run(userId);
+    return result.changes;
+  } finally {
+    db.close();
+  }
+}
+
+// Get all preferences for a user, including defaults for event types they
+// haven't customized. Returns an object keyed by event_type.
+function getPreferences(userId) {
+  const db = getDb();
+  try {
+    const rows = db.prepare(`
+      SELECT event_type, in_app, email FROM notification_preferences WHERE user_id = ?
+    `).all(userId);
+    const customByType = {};
+    for (const r of rows) customByType[r.event_type] = { in_app: r.in_app === 1, email: r.email === 1 };
+
+    const out = {};
+    for (const [eventType, meta] of Object.entries(EVENT_TYPES)) {
+      out[eventType] = {
+        label: meta.label,
+        description: meta.description,
+        in_app: customByType[eventType]?.in_app ?? meta.default.in_app === 1,
+        email: customByType[eventType]?.email ?? meta.default.email === 1,
+        is_default: !customByType[eventType],
+      };
+    }
+    return out;
+  } finally {
+    db.close();
+  }
+}
+
+// Update one preference. Throws if eventType is unknown.
+function setPreference(userId, eventType, { in_app, email }) {
+  if (!isKnownEventType(eventType)) {
+    throw new Error(`setPreference(): unknown event type "${eventType}"`);
+  }
+  const db = getDb();
+  try {
+    db.prepare(`
+      INSERT INTO notification_preferences (user_id, event_type, in_app, email)
+      VALUES (?, ?, ?, ?)
+      ON CONFLICT(user_id, event_type) DO UPDATE
+        SET in_app = excluded.in_app, email = excluded.email, updated_at = datetime('now')
+    `).run(userId, eventType, in_app ? 1 : 0, email ? 1 : 0);
+  } finally {
+    db.close();
+  }
+}
+
+// ── Internal helpers ─────────────────────────────────────────────────────────
+function safeJsonParse(s) {
+  try { return JSON.parse(s); } catch { return null; }
+}
+
+module.exports = {
+  EVENT_TYPES,
+  isKnownEventType,
+  notify,
+  notifyMany,
+  listForUser,
+  unreadCount,
+  markRead,
+  markAllRead,
+  getPreferences,
+  setPreference,
+};

--- a/server/services/scheduler.js
+++ b/server/services/scheduler.js
@@ -66,7 +66,24 @@ const schedulerService = {
       }
     }));
 
-    logger.info(`Scheduler started with ${this.jobs.length} jobs`);
+    // ── Email notification pipeline ──────────────────────────────────────
+    const emailIntervalSec = parseInt(process.env.NOTIFICATIONS_EMAIL_INTERVAL_SEC || '60', 10);
+    const emailCronExpr = emailIntervalSec >= 60
+      ? `*/${Math.floor(emailIntervalSec / 60)} * * * *`
+      : '* * * * *';
+    this.jobs.push(cron.schedule(emailCronExpr, async () => {
+      try {
+        const { processQueue } = require('./notifications-email');
+        const stats = await processQueue();
+        if (stats.processed > 0 || stats.skipped > 0) {
+          logger.info('Notifications email pipeline cycle', stats);
+        }
+      } catch (err) {
+        logger.error('Scheduler: notifications email pipeline failed', { error: err.message });
+      }
+    }));
+
+    logger.info(`Scheduler started with ${this.jobs.length} jobs (email pipeline interval: ${emailIntervalSec}s)`);
   },
 
   stop() {


### PR DESCRIPTION
## What

Introduces a complete in-app notifications backend for FireAlive: schema, canonical service module, user-facing routes, admin diagnostics, email delivery pipeline, scheduler integration, and the first wave of `notify()` calls into the events that should trigger notifications.

## Why

The MC and AC have an "Inbox" affordance and the platform has many natural notification-worthy moments (assessment assigned, retro scheduled, peer-share request, delegation decision, etc.) but no unified notification system existed. Before this PR, individual UI tabs scraped or polled their own state to surface "you have something new" hints, which was lossy and inconsistent. After this PR, every notification-worthy event flows through a single registry-backed service with per-user, per-event-type delivery preferences across in-app and email channels.

## Schema

Two tables + two indexes added to `server/db/init.js`:
- `notifications` — id (UUID), recipient_id (FK to users.id, cascade delete), event_type, title, body, link_tab, link_params (JSON), read_at, delivered_in_app, delivered_email, email_delivery_status (queued/sent/failed/bounced), created_at
- `notification_preferences` — (user_id, event_type) composite PK, in_app, email, updated_at
- Index on (recipient_id, read_at) WHERE read_at IS NULL — for the unread badge query
- Index on (recipient_id, created_at DESC) — for the full inbox list

## Service module

New `server/services/notifications.js`:
- Explicit `EVENT_TYPES` registry (currently 11 types: assessment_assigned, assessment_completed, retro_scheduled, retro_followup_sent, peer_request_posted, peer_request_accepted, peer_consent_mutual, peer_session_timed_out, iam_recert_due, helper_points_awarded, helper_redemption_approved, helper_redemption_denied, delegation_decision, routing_panic_engaged) — each declares default in_app/email channels, label, and description for the preferences UI
- `notify({recipientId, eventType, title, body, linkTab, linkParams})` — single entry point for all notifications
- `notifyMany()` — bulk variant
- `listForUser(userId, {includeRead, limit})` — paginated list for the inbox UI
- `unreadCount(userId)` — for the badge
- `markRead(userId, notificationId)` / `markAllRead(userId)` — scoped per-user
- `getPreferences(userId)` / `setPreference(userId, eventType, {in_app, email})` — preferences UI backend
- `getEligibleRecipients(eventType, {roles, activeOnly, excludeUserIds})` — for broadcast events; resolves preferences in bulk
- `getDailySendCount(userId, eventType, windowHours)` — supports daily-cap enforcement on opt-in broadcast events

`peer_request_posted` includes `dailyCap: 5` metadata that the wiring code respects.

## Routes

- `/api/inbox` — user-facing endpoints (list, unread-count, mark-read, mark-all-read, get-preferences, update-preference). Mounted with `authMiddleware(['analyst', 'lead', 'admin'])`.
- `/api/inbox/admin` — admin-only diagnostics (stats with per-status counts and recent failures, manual queue flush, single requeue, bulk requeue with optional bounce inclusion). Mounted with `authMiddleware(['admin'])`.

## Email pipeline

New `server/services/notifications-email.js` processes notifications with `email_delivery_status='queued'` via the team's configured channel (SMTP via Nodemailer, webhook POST, or PagerDuty Events API v2). Resolves channel from the existing `notification_config` row and SMTP env vars. Per-send 10s timeout. Distinguishes `bounced` (don't retry) from `failed` (admin can requeue). Logs failures to audit trail.

`nodemailer` ^6.9.16 added to `package.json` dependencies.

The pipeline is invoked by the scheduler service every 60s by default (configurable via `NOTIFICATIONS_EMAIL_INTERVAL_SEC`).

## Event wirings (first wave)

Nine events now generate notifications:

1. `assessment_assigned` — `routes/assessments.js` POST `/:id/assign`. Notifies each newly-assigned analyst (deduped against re-assignment).
2. `assessment_completed` — `routes/assessments.js` POST `/:id/results`. Notifies the assessment creator with the analyst's pseudonym (Tier-1 privacy) and skill-count.
3. `retro_scheduled` — `routes/retro.js` POST `/`. Notifies each analyst added to a CISM retrospective. Default in_app + email (time-sensitive).
4. `retro_followup_sent` — `routes/retro.js` POST `/:id/followup`. Notifies attached analysts when a 24hr/72hr/2-week check-in is sent. Returns 404 (rather than silent no-op) for nonexistent retros. Default in_app + email.
5. `peer_request_posted` — `routes/peers.js` POST `/requests`. Broadcasts to eligible helpers (analysts + leads, minus requester and exclude list). Opt-in only (default off both channels). Daily cap of 5 per recipient, enforced at send time.
6. `peer_request_accepted` — `routes/peers.js` POST `/requests/:id/accept`. Notifies the seeker. Helper identity stays hidden until mutual consent.
7. `peer_consent_mutual` — `routes/peers.js` POST `/sessions/:id/consent`. When second party consents, notifies the first consenter (who consented earlier and was waiting) with the now-revealed peer name.
8. `peer_session_timed_out` — `routes/peer-support.js` POST `/sessions/:id/timeout`. Notifies the seeker that their helper no-showed and the request was re-queued (or, in edge cases, that they need to re-post).
9. `delegation_decision` — `routes/delegations.js` PUT `/:id/review`. Notifies the analyst who submitted the delegation when a lead accepts or rejects, with optional reviewer notes. Adds 404 path for nonexistent delegations.

Every wiring follows the same pattern: notify call wrapped in try/catch with warn-level logging, never blocks or rolls back the underlying state change.

## What's NOT in this PR (deferred to Phase 1.4a part 2)

- `routing_panic_engaged_manual` / `routing_panic_engaged_tripwire` / `routing_panic_lifted` — panic mode and trip-wire (in `routes/v024-features.js`) need design refinement: mandatory in-app channel (can't opt out), broadcast to all analysts not leads, separate event types for manual vs trip-wire so analysts can have different preferences. Including the trip-wire bug fix (queries nonexistent `analysts` table — same class of bug as the v023 fix in Phase 1.3).
- `iam_recert_due` — needs a daily scheduled job in `services/scheduler.js` that calls the IAM check-absence logic and notifies leads about overdue analysts. Time-driven event.
- MC frontend inbox tab + unread badge + preferences UI in `frontend/socorra-v0031.jsx`
- AC frontend inbox tab + unread badge + preferences UI in `packages/analyst-client/analyst-client.jsx`

These are genuinely separable from the backend infrastructure landed here, and splitting the PR makes both reviewable.

## Verification

After merging:
- `node -e "const { initDb } = require('./server/db/init.js'); initDb();"` runs without errors and creates the new tables and indexes
- `npm install` picks up nodemailer
- `npm start` boots, scheduler logs `Scheduler started with N jobs (email pipeline interval: 60s)`
- POST `/api/inbox/preferences/assessment_assigned` with `{in_app: true, email: false}` updates the preference; GET returns the updated effective preferences
- Assigning an assessment triggers a row in `notifications` for each new assignee
- An admin POST to `/api/inbox/admin/flush-queue` returns the cycle stats

## Phase context

Phase 1, step 1.4, sub-phase 1.4a (part 1 of 2). After this merges and v1.0.9 ships, sub-phase 1.4a part 2 picks up panic mode, trip-wire, IAM recertification daily job, and the MC/AC frontend wirings. After 1.4a is fully complete, sub-phases 1.4b–1.4j build out IR runbooks (org-policy-driven), tiered abuse flagging, TTX generator, helper pay (with redemption), cloud vuln scanning, cloud IaC packaging, CI/CD integration, regression test runner, frontend URL repointing, and the final dead-code sweep.
