### PR TITLE
package: bump version to 1.0.9 and fuse counter to 2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "firealive",
-  "version": "1.0.8",
-  "fuseCounter": 1,
+  "version": "1.0.9",
+  "fuseCounter": 2,
   "buildId": "20260429.1",
   "description": "FireAlive — SOC Analyst Wellbeing Platform. Burnout-aware ticket routing, peer skill-share, post-incident wellness, skills assessments, and team health monitoring with privacy-first architecture.",
   "main": "server/index.js",


### PR DESCRIPTION
The v1.0.9 release was tagged on GitHub but package.json was never updated, so the running app reports itself as v1.0.8. lib/version.js is the canonical version source and reads both fields from package.json, which means CEF audit messages, the startup log line, the system meta table, and any place that calls cefDeviceVersion are all reporting the wrong version.

Bumping the fuse counter from 1 to 2 because v1.0.9 has shipped to a public release. The anti-rollback check in initDb writes the package.json fuseCounter value into system_meta on first boot of a new install, and if the stored counter is later observed to exceed the package.json counter on a subsequent boot, that is a rollback attempt and the app refuses to start (see system.js FUSE_VIOLATION handler).

Build ID intentionally left at 20260429.1 — that was the actual v1.0.9 build day. The next bump will be in the final commit of Phase 1.4a Part 2 when we tag v1.0.10.

Phase 1.4a Part 2 fix-up.