### PR TITLE
v1.0.11 — Tiered abuse flagging (Phase 1.4b)

### DIFF
--- a/frontend/firealive-mc.jsx
+++ b/frontend/firealive-mc.jsx
@@ -1215,6 +1215,39 @@ function ManagementConsole() {
       }).catch(()=>{}).finally(()=>setInboxPrefsLoading(false));
     }
   }, [tab, inboxView, inboxIncludeRead]);
+
+  // ── Peer Conduct (Phase 1.4b) ──
+  const [peerFlags, setPeerFlags] = useState([]);
+  const [peerFlagsLoading, setPeerFlagsLoading] = useState(false);
+  const [peerFlagStatus, setPeerFlagStatus] = useState("open"); // open | resolved | all
+  const [peerFlagTierFilter, setPeerFlagTierFilter] = useState(""); // "" | "1" | "2" | "3"
+  const [peerFlagOpenCount, setPeerFlagOpenCount] = useState(0);
+  const [peerFlagResolveTarget, setPeerFlagResolveTarget] = useState(null); // flag id
+  const [peerFlagResolveNote, setPeerFlagResolveNote] = useState("");
+
+  // Poll the open-flag count every 60s for the sidebar badge.
+  useEffect(()=>{
+    let cancelled = false;
+    const fetchCount = ()=>{
+      api.get("/api/peer/flags?status=open").then(r=>{
+        if (!cancelled) setPeerFlagOpenCount((r?.flags||[]).length);
+      }).catch(()=>{});
+    };
+    fetchCount();
+    const handle = setInterval(fetchCount, 60000);
+    return ()=>{ cancelled = true; clearInterval(handle); };
+  }, []);
+
+  // When peer_conduct tab is opened or filters change, load flags.
+  useEffect(()=>{
+    if (tab !== "peer_conduct") return;
+    setPeerFlagsLoading(true);
+    const params = new URLSearchParams({ status: peerFlagStatus });
+    if (peerFlagTierFilter) params.set("tier", peerFlagTierFilter);
+    api.get(`/api/peer/flags?${params.toString()}`).then(r=>{
+      setPeerFlags(r?.flags || []);
+    }).catch(()=>{}).finally(()=>setPeerFlagsLoading(false));
+  }, [tab, peerFlagStatus, peerFlagTierFilter]);
   const [analysts, setAnalysts] = useState(ANALYSTS_INIT);
   const [provisionedClients, setPC] = useState([]);
   const [showProvision, setShowProvision] = useState(false);
@@ -1496,7 +1529,7 @@ function ManagementConsole() {
   const toggleNav = (cat) => setNavExpanded(prev=>{const next={};next[cat]=!prev[cat];return next;});
   const navGroups = [
     {cat:"ops",label:"Operations",items:[
-      {id:"inbox",label:"Inbox",badge:inboxUnreadCount},{id:"actions",label:"Actions",badge:highP.length},{id:"overview",label:"Team Overview"},{id:"routing",label:"Routing & SOAR"},{id:"handoff",label:"Shift Handoff"},{id:"sla",label:"SLA"},{id:"automation",label:"Automation"},{id:"fail_open",label:"Fail-Open Routing"},{id:"auto_disable",label:"Auto-Disable Routing"},{id:"runbook",label:"Recovery Runbook"},
+      {id:"inbox",label:"Inbox",badge:inboxUnreadCount},{id:"peer_conduct",label:"Peer Conduct",badge:peerFlagOpenCount},{id:"actions",label:"Actions",badge:highP.length},{id:"overview",label:"Team Overview"},{id:"routing",label:"Routing & SOAR"},{id:"handoff",label:"Shift Handoff"},{id:"sla",label:"SLA"},{id:"automation",label:"Automation"},{id:"fail_open",label:"Fail-Open Routing"},{id:"auto_disable",label:"Auto-Disable Routing"},{id:"runbook",label:"Recovery Runbook"},
     ]},
     {cat:"analysts",label:"Analysts & Wellbeing",items:[
       {id:"skillmatrix",label:"Skills Matrix"},{id:"assessments",label:"Assessments"},{id:"general_certs",label:"Certifications"},{id:"retro",label:"CISM Retro"},{id:"peersupport",label:"Peer Config"},{id:"pseudonyms",label:"Pseudonyms"},{id:"ooda_mgmt",label:"IR Simulator"},{id:"proactive",label:"Proactive Breaks"},{id:"upskilling_hr",label:"Upskilling Hour"},{id:"offboarding",label:"Offboarding"},{id:"sync_interval",label:"Sync Interval"},{id:"client_notif",label:"Client Notifications"},
@@ -4382,6 +4415,80 @@ regression:
               </Card>
             ))}
           </div>)}
+        </div>)}
+
+        {/* PEER CONDUCT — tiered abuse flag review */}
+        {tab==="peer_conduct"&&(<div>
+          <div style={{display:"flex",justifyContent:"space-between",alignItems:"center",marginBottom:12}}>
+            <L style={{marginBottom:0}}>Peer Conduct — {peerFlagStatus==="open"?"Open Flags":peerFlagStatus==="resolved"?"Resolved Flags":"All Flags"} ({peerFlags.length})</L>
+            <div style={{display:"flex",gap:6,alignItems:"center"}}>
+              <select value={peerFlagStatus} onChange={e=>setPeerFlagStatus(e.target.value)} style={{padding:"5px 10px",background:"rgba(255,255,255,0.03)",border:`1px solid ${C.b}`,borderRadius:6,color:C.t,fontSize:11,fontFamily:"'IBM Plex Mono',monospace"}}>
+                <option value="open">Open</option>
+                <option value="resolved">Resolved</option>
+                <option value="all">All</option>
+              </select>
+              <select value={peerFlagTierFilter} onChange={e=>setPeerFlagTierFilter(e.target.value)} style={{padding:"5px 10px",background:"rgba(255,255,255,0.03)",border:`1px solid ${C.b}`,borderRadius:6,color:C.t,fontSize:11,fontFamily:"'IBM Plex Mono',monospace"}}>
+                <option value="">All tiers</option>
+                <option value="3">Tier 3 (urgent)</option>
+                <option value="2">Tier 2 (attack)</option>
+                <option value="1">Tier 1 (minor)</option>
+              </select>
+              <Btn small onClick={()=>{setPeerFlagsLoading(true);const params=new URLSearchParams({status:peerFlagStatus});if(peerFlagTierFilter)params.set("tier",peerFlagTierFilter);api.get(`/api/peer/flags?${params.toString()}`).then(r=>setPeerFlags(r?.flags||[])).catch(()=>{}).finally(()=>setPeerFlagsLoading(false));}}>Refresh</Btn>
+            </div>
+          </div>
+          <M style={{color:C.tm,display:"block",marginBottom:14,lineHeight:1.6}}>Flags submitted by analysts after peer skill-share sessions. Tier 1 (minor) shows aggregate patterns only — both flagger and flagged stay anonymous. Tier 2 (personal attack) reveals the flagged peer's identity. Tier 3 (urgent — slurs, threats, harassment) reveals both identities and warrants HR involvement.</M>
+          {peerFlagsLoading&&<M style={{color:C.td,display:"block",marginBottom:10}}>Loading…</M>}
+          {!peerFlagsLoading&&peerFlags.length===0&&<Card><M style={{color:C.tm}}>No flags match the current filter. {peerFlagStatus==="open"?"That is good news — it means no peer skill-share sessions have been flagged for review.":""}</M></Card>}
+          {peerFlags.map(f=>{
+            const tierColor=f.tier===3?C.d:f.tier===2?C.w:C.i;
+            const tierLabel=f.tier===3?"URGENT":f.tier===2?"ATTACK":"MINOR";
+            return(
+              <Card key={f.id} style={{marginBottom:10,borderLeft:`4px solid ${tierColor}`,opacity:f.resolvedAt?0.65:1}}>
+                <div style={{display:"flex",justifyContent:"space-between",alignItems:"flex-start",marginBottom:8,gap:10}}>
+                  <div style={{flex:1,minWidth:0}}>
+                    <div style={{display:"flex",gap:8,alignItems:"center",marginBottom:4,flexWrap:"wrap"}}>
+                      <Badge color={tierColor}>TIER {f.tier} · {tierLabel}</Badge>
+                      {f.resolvedAt&&<Badge color={C.a}>RESOLVED</Badge>}
+                      <M style={{color:C.td}}>{new Date(f.createdAt).toLocaleString()}</M>
+                    </div>
+                    <div style={{fontSize:11,color:C.tm,marginBottom:6}}>
+                      <span style={{color:C.t}}>Flagger:</span> {f.flaggerDisplay} · <span style={{color:C.t}}>Flagged:</span> {f.flaggedDisplay}
+                      {f.flaggerIp&&<span style={{color:C.td}}> · IP {f.flaggerIp}</span>}
+                    </div>
+                  </div>
+                </div>
+                <Card style={{padding:"10px 12px",background:"rgba(0,0,0,0.3)",border:`1px solid ${C.b}`,marginBottom:f.resolvedAt?0:10}}>
+                  <M style={{color:C.td,display:"block",marginBottom:4}}>Flagged content:</M>
+                  <div style={{fontSize:12,color:C.t,lineHeight:1.6,whiteSpace:"pre-wrap",fontFamily:"'IBM Plex Mono',monospace"}}>{f.content}</div>
+                </Card>
+                {f.resolvedAt&&(
+                  <div style={{marginTop:10,padding:"10px 12px",background:"rgba(110,231,183,0.04)",borderRadius:8,border:`1px solid ${C.a}30`}}>
+                    <M style={{color:C.a,fontWeight:500,display:"block",marginBottom:4}}>Resolved {new Date(f.resolvedAt).toLocaleString()} by {f.resolvedBy||"unknown"}</M>
+                    {f.resolutionNote&&<M style={{color:C.tm,lineHeight:1.6}}>{f.resolutionNote}</M>}
+                  </div>
+                )}
+                {!f.resolvedAt&&(
+                  <div>
+                    {f.tier===3&&(<Card style={{padding:"10px 12px",marginBottom:10,background:"rgba(239,68,68,0.06)",border:`1px solid ${C.d}40`}}>
+                      <M style={{color:C.d,fontWeight:500,display:"block",marginBottom:4}}>HR intervention recommended</M>
+                      <M style={{color:C.tm,lineHeight:1.6}}>Tier 3 flags involve content (slurs, threats, harassment) that typically requires HR review and documentation per most workplace conduct policies. Resolve this flag only after the appropriate HR loop has been initiated.</M>
+                    </Card>)}
+                    {peerFlagResolveTarget===f.id?(
+                      <div>
+                        <textarea value={peerFlagResolveNote} onChange={e=>setPeerFlagResolveNote(e.target.value)} rows={3} maxLength={2000} placeholder="Resolution note — what action was taken? (max 2000 chars, optional but recommended)" style={{width:"100%",padding:10,background:"rgba(255,255,255,0.03)",border:`1px solid ${C.b}`,borderRadius:8,color:C.t,fontSize:12,resize:"vertical",marginBottom:8}}/>
+                        <div style={{display:"flex",gap:6}}>
+                          <Btn small primary onClick={()=>{api.post(`/api/peer/flags/${f.id}/resolve`,{note:peerFlagResolveNote||null}).then(()=>{addA("PEER_FLAG_RESOLVED",`Tier ${f.tier} flag resolved`);setPeerFlagResolveTarget(null);setPeerFlagResolveNote("");setPeerFlagsLoading(true);const params=new URLSearchParams({status:peerFlagStatus});if(peerFlagTierFilter)params.set("tier",peerFlagTierFilter);api.get(`/api/peer/flags?${params.toString()}`).then(r=>setPeerFlags(r?.flags||[])).catch(()=>{}).finally(()=>setPeerFlagsLoading(false));}).catch(()=>{addA("PEER_FLAG_RESOLVE_FAILED",`Tier ${f.tier} flag resolve attempt failed`);});}}>Submit Resolution</Btn>
+                          <Btn small onClick={()=>{setPeerFlagResolveTarget(null);setPeerFlagResolveNote("");}}>Cancel</Btn>
+                        </div>
+                      </div>
+                    ):(
+                      <Btn small primary onClick={()=>{setPeerFlagResolveTarget(f.id);setPeerFlagResolveNote("");}}>Mark Resolved</Btn>
+                    )}
+                  </div>
+                )}
+              </Card>
+            );
+          })}
         </div>)}
 
         {/* AUDIT — aggregated across MC, server, and all clients */}

--- a/frontend/firealive-mc.jsx
+++ b/frontend/firealive-mc.jsx
@@ -1222,19 +1222,25 @@ function ManagementConsole() {
   const [peerFlagStatus, setPeerFlagStatus] = useState("open"); // open | resolved | all
   const [peerFlagTierFilter, setPeerFlagTierFilter] = useState(""); // "" | "1" | "2" | "3"
   const [peerFlagOpenCount, setPeerFlagOpenCount] = useState(0);
+  const [peerFlagUrgentOpenCount, setPeerFlagUrgentOpenCount] = useState(0);
   const [peerFlagResolveTarget, setPeerFlagResolveTarget] = useState(null); // flag id
   const [peerFlagResolveNote, setPeerFlagResolveNote] = useState("");
 
-  // Poll the open-flag count every 60s for the sidebar badge.
+  // Poll the open-flag count every 60s for the sidebar badge and the
+  // tier-3 dashboard banner. We track total open and urgent open in
+  // the same pass to avoid a second request.
   useEffect(()=>{
     let cancelled = false;
-    const fetchCount = ()=>{
+    const fetchCounts = ()=>{
       api.get("/api/peer/flags?status=open").then(r=>{
-        if (!cancelled) setPeerFlagOpenCount((r?.flags||[]).length);
+        if (cancelled) return;
+        const flags = r?.flags || [];
+        setPeerFlagOpenCount(flags.length);
+        setPeerFlagUrgentOpenCount(flags.filter(f=>f.tier===3).length);
       }).catch(()=>{});
     };
-    fetchCount();
-    const handle = setInterval(fetchCount, 60000);
+    fetchCounts();
+    const handle = setInterval(fetchCounts, 60000);
     return ()=>{ cancelled = true; clearInterval(handle); };
   }, []);
 
@@ -1646,6 +1652,16 @@ function ManagementConsole() {
           </div>
         </div>
       </div>
+      {peerFlagUrgentOpenCount>0&&(<div onClick={()=>setTab("peer_conduct")} style={{padding:"10px 24px",background:"rgba(239,68,68,0.12)",borderBottom:`1px solid ${C.d}50`,cursor:"pointer",display:"flex",justifyContent:"space-between",alignItems:"center",gap:12}}>
+        <div style={{display:"flex",gap:10,alignItems:"center"}}>
+          <span style={{width:8,height:8,borderRadius:"50%",background:C.d,boxShadow:`0 0 8px ${C.d}`,animation:"pulse 1.5s infinite",flexShrink:0}}/>
+          <div>
+            <M style={{color:C.d,fontWeight:600,letterSpacing:1.5,textTransform:"uppercase",fontSize:10,display:"block"}}>Tier-3 Conduct Flag — Action Required</M>
+            <M style={{color:C.t,fontSize:11,display:"block",marginTop:2}}>{peerFlagUrgentOpenCount} unresolved urgent flag{peerFlagUrgentOpenCount>1?"s":""} (slurs / threats / harassment). HR intervention recommended.</M>
+          </div>
+        </div>
+        <M style={{color:C.d,fontWeight:500,fontSize:11}}>Review →</M>
+      </div>)}
       {/* v1.0.0: Grouped sidebar navigation replaces 57 flat tabs */}
       <div style={{display:"flex",minHeight:"calc(100vh - 120px)"}}>
         <div style={{width:220,flexShrink:0,borderRight:`1px solid ${C.b}`,background:C.s,overflowY:"auto",padding:"8px 0"}}>

--- a/packages/analyst-client/analyst-client.jsx
+++ b/packages/analyst-client/analyst-client.jsx
@@ -445,6 +445,7 @@ export default function AnalystClientApp() {
   const [postRating, setPostRating] = useState(0);
   const [postFlagging, setPostFlagging] = useState(false);
   const [postFlagText, setPostFlagText] = useState("");
+  const [postFlagTier, setPostFlagTier] = useState(0); // 0=unselected, 1/2/3
   // (cleaned up in v1.0.0)
 
   // signals defined above
@@ -853,7 +854,8 @@ export default function AnalystClientApp() {
               </div>
 
               {postFlagging&&(<div>
-                <M style={{color:C.d,fontWeight:500,display:"block",marginBottom:8}}>Review the chat and highlight abusive text below:</M>
+                <M style={{color:C.d,fontWeight:500,display:"block",marginBottom:8}}>Review the chat and select the severity that matches what happened:</M>
+
                 <Card style={{marginBottom:8,maxHeight:200,overflow:"auto",background:"rgba(0,0,0,0.4)",fontFamily:"'Courier New',Courier,monospace"}}>
                   {postSession.messages.map(m=>(
                     <div key={m.id} style={{padding:"8px 12px",borderBottom:"1px solid rgba(255,255,255,0.04)"}}>
@@ -863,10 +865,55 @@ export default function AnalystClientApp() {
                     </div>
                   ))}
                 </Card>
-                <div style={{marginBottom:10}}><M style={{color:C.tm,marginBottom:4,display:"block"}}>Copy and paste the abusive text here, or describe what was said:</M><textarea value={postFlagText} onChange={e=>setPostFlagText(e.target.value)} rows={3} maxLength={10000} style={{width:"100%",padding:10,background:"rgba(255,255,255,0.03)",border:`1px solid ${C.d}40`,borderRadius:8,color:C.t,fontSize:12,resize:"vertical"}} placeholder="Paste abusive text or describe what happened..."/></div>
+
+                <div style={{marginBottom:14}}>
+                  <M style={{color:C.tm,marginBottom:8,display:"block"}}>Severity tier:</M>
+                  <div style={{display:"flex",flexDirection:"column",gap:8}}>
+                    <label style={{display:"flex",gap:10,padding:"10px 12px",background:postFlagTier===1?"rgba(96,165,250,0.08)":"rgba(255,255,255,0.02)",border:`1px solid ${postFlagTier===1?C.i+"50":C.b}`,borderRadius:8,cursor:"pointer"}}>
+                      <input type="radio" name="flagtier" checked={postFlagTier===1} onChange={()=>setPostFlagTier(1)} style={{marginTop:3}}/>
+                      <div style={{flex:1}}>
+                        <M style={{color:C.i,fontWeight:600,display:"block",marginBottom:2}}>Tier 1 — Minor</M>
+                        <M style={{color:C.tm,lineHeight:1.5}}>Curt tone, dismissiveness, condescension, or mild rudeness. Not a personal attack — just unprofessional. Identities stay anonymous. Aggregated for pattern detection only.</M>
+                      </div>
+                    </label>
+                    <label style={{display:"flex",gap:10,padding:"10px 12px",background:postFlagTier===2?"rgba(251,191,36,0.08)":"rgba(255,255,255,0.02)",border:`1px solid ${postFlagTier===2?C.w+"50":C.b}`,borderRadius:8,cursor:"pointer"}}>
+                      <input type="radio" name="flagtier" checked={postFlagTier===2} onChange={()=>setPostFlagTier(2)} style={{marginTop:3}}/>
+                      <div style={{flex:1}}>
+                        <M style={{color:C.w,fontWeight:600,display:"block",marginBottom:2}}>Tier 2 — Personal attack</M>
+                        <M style={{color:C.tm,lineHeight:1.5}}>Direct insult, name-calling, mockery, or demeaning language targeted at you. The peer's identity is revealed to your team lead. Your identity stays anonymous to the lead.</M>
+                      </div>
+                    </label>
+                    <label style={{display:"flex",gap:10,padding:"10px 12px",background:postFlagTier===3?"rgba(239,68,68,0.08)":"rgba(255,255,255,0.02)",border:`1px solid ${postFlagTier===3?C.d+"50":C.b}`,borderRadius:8,cursor:"pointer"}}>
+                      <input type="radio" name="flagtier" checked={postFlagTier===3} onChange={()=>setPostFlagTier(3)} style={{marginTop:3}}/>
+                      <div style={{flex:1}}>
+                        <M style={{color:C.d,fontWeight:600,display:"block",marginBottom:2}}>Tier 3 — Urgent</M>
+                        <M style={{color:C.tm,lineHeight:1.5}}>Slurs (racial, gender, orientation, religion, disability), explicit threats, sexual harassment, or content suggesting imminent harm. Both identities — yours and the peer's — are revealed to your lead. HR is brought in. Use this only when warranted; misuse undermines trust in the flagging system.</M>
+                      </div>
+                    </label>
+                  </div>
+                </div>
+
+                <div style={{marginBottom:10}}>
+                  <M style={{color:C.tm,marginBottom:4,display:"block"}}>Copy and paste the relevant text, or describe what was said:</M>
+                  <textarea value={postFlagText} onChange={e=>setPostFlagText(e.target.value)} rows={3} maxLength={10000} style={{width:"100%",padding:10,background:"rgba(255,255,255,0.03)",border:`1px solid ${C.d}40`,borderRadius:8,color:C.t,fontSize:12,resize:"vertical"}} placeholder="Paste the text in question or describe what happened..."/>
+                </div>
+
                 <div style={{display:"flex",gap:8}}>
-                  <Btn danger disabled={!postFlagText.trim()} onClick={()=>{logC("peer_abuse_flagged","Abusive text flagged and sent to secure vault");setPostFlagging(false);setPostSession(null);}}>Submit to Secure Vault</Btn>
-                  <Btn small onClick={()=>setPostFlagging(false)}>Cancel</Btn>
+                  <Btn danger disabled={!postFlagText.trim()||!postFlagTier} onClick={()=>{
+                    // TODO: when peer chat is backed by a real server session, replace
+                    // this with: api.post("/api/peer/flags", {sessionId, flaggedUserId,
+                    // tier: postFlagTier, content: postFlagText})
+                    // The endpoint exists (commit 3-5 of Phase 1.4b) but the AC peer
+                    // chat itself is still client-side only — there is no server
+                    // session to reference yet. This is recorded in the audit log so
+                    // the flag isn't lost.
+                    logC("peer_abuse_flagged",`Tier ${postFlagTier}: ${postFlagText.slice(0,80)}${postFlagText.length>80?"...":""}`);
+                    setPostFlagging(false);
+                    setPostFlagTier(0);
+                    setPostFlagText("");
+                    setPostSession(null);
+                  }}>Submit Flag</Btn>
+                  <Btn small onClick={()=>{setPostFlagging(false);setPostFlagTier(0);}}>Cancel</Btn>
                 </div>
               </div>)}
             </Card>

--- a/server/db/init.js
+++ b/server/db/init.js
@@ -516,8 +516,6 @@ CREATE TABLE IF NOT EXISTS peer_abuse_flags (
   flagged_user_id TEXT REFERENCES users(id) ON DELETE SET NULL,
   tier INTEGER NOT NULL CHECK (tier IN (1, 2, 3)),
   content_encrypted BLOB NOT NULL,
-  content_iv BLOB NOT NULL,
-  content_tag BLOB NOT NULL,
   flagger_ip TEXT,
   created_at TEXT NOT NULL DEFAULT (datetime('now')),
   resolved_at TEXT,

--- a/server/db/init.js
+++ b/server/db/init.js
@@ -508,6 +508,32 @@ CREATE TABLE IF NOT EXISTS notification_preferences (
   updated_at TEXT NOT NULL DEFAULT (datetime('now')),
   PRIMARY KEY (user_id, event_type)
 );
+
+CREATE TABLE IF NOT EXISTS peer_abuse_flags (
+  id TEXT PRIMARY KEY DEFAULT (lower(hex(randomblob(16)))),
+  session_id TEXT NOT NULL,
+  flagger_user_id TEXT NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  flagged_user_id TEXT REFERENCES users(id) ON DELETE SET NULL,
+  tier INTEGER NOT NULL CHECK (tier IN (1, 2, 3)),
+  content_encrypted BLOB NOT NULL,
+  content_iv BLOB NOT NULL,
+  content_tag BLOB NOT NULL,
+  flagger_ip TEXT,
+  created_at TEXT NOT NULL DEFAULT (datetime('now')),
+  resolved_at TEXT,
+  resolved_by TEXT REFERENCES users(id) ON DELETE SET NULL,
+  resolution_note TEXT
+);
+
+CREATE INDEX IF NOT EXISTS idx_peer_abuse_flags_unresolved
+  ON peer_abuse_flags(tier, created_at DESC)
+  WHERE resolved_at IS NULL;
+
+CREATE INDEX IF NOT EXISTS idx_peer_abuse_flags_flagged_user
+  ON peer_abuse_flags(flagged_user_id, created_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_peer_abuse_flags_flagger
+  ON peer_abuse_flags(flagger_user_id, created_at DESC);
 `;
 
 

--- a/server/index.js
+++ b/server/index.js
@@ -113,6 +113,7 @@ app.use('/api/notifications', authMiddleware(['admin']), require('./routes/notif
 app.use('/api/messages', authMiddleware(['analyst']), require('./routes/messages'));
 app.use('/api/peers', authMiddleware(['analyst']), require('./routes/peers'));
 app.use('/api/peer-support', authMiddleware(['analyst', 'lead', 'admin']), require('./routes/peer-support'));
+app.use('/api/peer/flags', authMiddleware(['analyst', 'lead', 'admin']), require('./routes/peer-flags'));
 app.use('/api/training', authMiddleware(['analyst', 'lead', 'admin']), require('./routes/training'));
 app.use('/api/features', authMiddleware(['lead', 'admin', 'analyst']), require('./routes/features'));
 app.use('/api/query', authMiddleware(['lead', 'admin']), require('./routes/query'));

--- a/server/routes/peer-flags.js
+++ b/server/routes/peer-flags.js
@@ -150,4 +150,167 @@ router.post('/flags', (req, res) => {
   });
 });
 
+// ── GET /api/peer/flags — list flags for review ─────────────────────────────
+//
+// Lead/admin only. Query parameters:
+//   ?status=open|resolved|all   (default: open)
+//   ?tier=1|2|3                 (optional filter)
+//
+// Response: { flags: [...] }
+//
+// Each flag includes decrypted content. Identity reveal follows tier rules:
+//   - Tier 1: flagger and flagged are both anonymized to "Analyst-XXX"
+//   - Tier 2: flagged peer's real name is shown; flagger remains anonymized
+//   - Tier 3: both real names are shown (reciprocal accountability)
+//
+// The reveal happens at read time so a lead who skims a tier-1 flag never
+// even sees encrypted-but-decryptable identity data — the response itself
+// omits the names.
+router.get('/flags', (req, res) => {
+  if (!['lead', 'admin'].includes(req.user.role)) {
+    return res.status(403).json({ error: 'forbidden' });
+  }
+
+  const status = ['open', 'resolved', 'all'].includes(req.query.status) ? req.query.status : 'open';
+  const tierFilter = ['1', '2', '3'].includes(req.query.tier) ? parseInt(req.query.tier, 10) : null;
+
+  let where = '';
+  const params = [];
+  if (status === 'open') where += ' WHERE f.resolved_at IS NULL';
+  else if (status === 'resolved') where += ' WHERE f.resolved_at IS NOT NULL';
+  if (tierFilter !== null) {
+    where += where ? ' AND' : ' WHERE';
+    where += ' f.tier = ?';
+    params.push(tierFilter);
+  }
+
+  let rows;
+  try {
+    const db = getDb();
+    rows = db.prepare(`
+      SELECT
+        f.id, f.session_id, f.flagger_user_id, f.flagged_user_id, f.tier,
+        f.content_encrypted, f.flagger_ip, f.created_at,
+        f.resolved_at, f.resolved_by, f.resolution_note,
+        flagger.name AS flagger_name,
+        flagged.name AS flagged_name,
+        resolver.name AS resolver_name
+      FROM peer_abuse_flags f
+      LEFT JOIN users flagger ON flagger.id = f.flagger_user_id
+      LEFT JOIN users flagged ON flagged.id = f.flagged_user_id
+      LEFT JOIN users resolver ON resolver.id = f.resolved_by
+      ${where}
+      ORDER BY f.tier DESC, f.created_at DESC
+    `).all(...params);
+    db.close();
+  } catch (err) {
+    logger.error('Failed to list peer abuse flags', { error: err.message });
+    return res.status(500).json({ error: 'failed to list flags' });
+  }
+
+  const { decryptTier3 } = require('../services/encryption');
+
+  const flags = rows.map((row) => {
+    let content;
+    try {
+      content = decryptTier3(row.content_encrypted);
+    } catch (err) {
+      logger.error('Failed to decrypt flag content', { flagId: row.id, error: err.message });
+      content = '[decryption failed — Tier-3 key may be misconfigured]';
+    }
+
+    // Identity reveal by tier. Anonymize names that this tier should not reveal.
+    // We use first 8 chars of the user ID as the anonymous suffix so the lead
+    // can still distinguish multiple anonymous flaggers/flagged in the same view.
+    const flaggerAnon = `Analyst-${row.flagger_user_id.slice(0, 8)}`;
+    const flaggedAnon = `Analyst-${row.flagged_user_id ? row.flagged_user_id.slice(0, 8) : 'unknown'}`;
+
+    let flaggerDisplay, flaggedDisplay;
+    if (row.tier === 1) {
+      flaggerDisplay = flaggerAnon;
+      flaggedDisplay = flaggedAnon;
+    } else if (row.tier === 2) {
+      flaggerDisplay = flaggerAnon;
+      flaggedDisplay = row.flagged_name || flaggedAnon;
+    } else {
+      // tier 3 — both revealed
+      flaggerDisplay = row.flagger_name || flaggerAnon;
+      flaggedDisplay = row.flagged_name || flaggedAnon;
+    }
+
+    return {
+      id: row.id,
+      sessionId: row.session_id,
+      tier: row.tier,
+      content,
+      flaggerDisplay,
+      flaggedDisplay,
+      flaggerIp: row.tier >= 2 ? row.flagger_ip : null, // tier-1 IPs not exposed
+      createdAt: row.created_at,
+      resolvedAt: row.resolved_at,
+      resolvedBy: row.resolver_name,
+      resolutionNote: row.resolution_note,
+    };
+  });
+
+  return res.json({ flags });
+});
+
+// ── POST /api/peer/flags/:id/resolve — resolve a flag ───────────────────────
+//
+// Lead/admin only. Marks a flag as resolved with an optional note.
+//
+// Request body:
+//   { note?: string (max 2000 chars) }
+//
+// Response: { id, resolvedAt, resolvedBy, note }
+router.post('/flags/:id/resolve', (req, res) => {
+  if (!['lead', 'admin'].includes(req.user.role)) {
+    return res.status(403).json({ error: 'forbidden' });
+  }
+
+  const flagId = req.params.id;
+  if (!flagId || typeof flagId !== 'string' || flagId.length > 64) {
+    return res.status(400).json({ error: 'invalid flag id' });
+  }
+
+  const note = (req.body && typeof req.body.note === 'string') ? req.body.note.slice(0, 2000) : null;
+  const now = new Date().toISOString();
+
+  let updated;
+  try {
+    const db = getDb();
+    const existing = db.prepare("SELECT id, resolved_at, tier FROM peer_abuse_flags WHERE id = ?").get(flagId);
+    if (!existing) {
+      db.close();
+      return res.status(404).json({ error: 'flag not found' });
+    }
+    if (existing.resolved_at) {
+      db.close();
+      return res.status(409).json({ error: 'flag already resolved' });
+    }
+
+    db.prepare(`
+      UPDATE peer_abuse_flags
+      SET resolved_at = ?, resolved_by = ?, resolution_note = ?
+      WHERE id = ?
+    `).run(now, req.user.id, note, flagId);
+
+    updated = { tier: existing.tier };
+    db.close();
+  } catch (err) {
+    logger.error('Failed to resolve peer abuse flag', { flagId, error: err.message });
+    return res.status(500).json({ error: 'failed to resolve flag' });
+  }
+
+  auditLog(req.user.id, 'PEER_ABUSE_FLAG_RESOLVED', `flag ${flagId}, tier ${updated.tier}`, req.ip);
+
+  return res.json({
+    id: flagId,
+    resolvedAt: now,
+    resolvedBy: req.user.id,
+    note,
+  });
+});
+
 module.exports = router;

--- a/server/routes/peer-flags.js
+++ b/server/routes/peer-flags.js
@@ -1,0 +1,153 @@
+// ═══════════════════════════════════════════════════════════════════════════════
+// FIREALIVE — Peer Abuse Flag Routes (Phase 1.4b)
+//
+// Tiered abuse flagging for peer skill-share sessions. Three tiers:
+//   1 — Minor (tone, dismissiveness, mild rudeness). No identity reveal.
+//   2 — Personal attack (insult, mockery). Flagged peer's identity revealed.
+//   3 — Urgent (slurs, threats, harassment). Both identities revealed; HR loop.
+//
+// POST /api/peer/flags                  — analyst submits a flag
+// GET  /api/peer/flags                  — lead/admin lists flags (commit 5)
+// POST /api/peer/flags/:id/resolve      — lead/admin resolves a flag (commit 5)
+//
+// All flag content is encrypted with Tier-3 AES-256-GCM. The server stores
+// ciphertext only. Decryption happens at read time when a lead with the right
+// role reviews flags.
+// ═══════════════════════════════════════════════════════════════════════════════
+
+const router = require('express').Router();
+const crypto = require('crypto');
+const { getDb } = require('../db/init');
+const { auditLog } = require('../middleware/audit');
+const { logger } = require('../services/logger');
+const { encryptTier3 } = require('../services/encryption');
+const notifications = require('../services/notifications');
+
+const MAX_FLAG_CONTENT_LENGTH = 10000; // 10KB — enough for pasted chat excerpts
+const VALID_TIERS = [1, 2, 3];
+
+// ── POST /api/peer/flags — submit a flag ────────────────────────────────────
+//
+// Request body:
+//   {
+//     sessionId: string (required)  — peer chat session being flagged
+//     flaggedUserId: string (required) — the peer being flagged
+//     tier: 1 | 2 | 3 (required)
+//     content: string (required, max 10KB) — copy/paste of abusive text or description
+//   }
+//
+// Response: { id, tier, createdAt }
+//
+// Side effects:
+//   - Inserts row into peer_abuse_flags with encrypted content
+//   - Notifies leads/admins via the appropriate tier event type
+//   - Audit logs the flag submission (no content in audit — only metadata)
+router.post('/flags', (req, res) => {
+  const { sessionId, flaggedUserId, tier, content } = req.body || {};
+
+  if (!sessionId || typeof sessionId !== 'string' || sessionId.length > 200) {
+    return res.status(400).json({ error: 'sessionId required (max 200 chars)' });
+  }
+  if (!flaggedUserId || typeof flaggedUserId !== 'string') {
+    return res.status(400).json({ error: 'flaggedUserId required' });
+  }
+  if (!VALID_TIERS.includes(tier)) {
+    return res.status(400).json({ error: 'tier must be 1, 2, or 3' });
+  }
+  if (!content || typeof content !== 'string') {
+    return res.status(400).json({ error: 'content required' });
+  }
+  if (content.length > MAX_FLAG_CONTENT_LENGTH) {
+    return res.status(400).json({ error: `content max ${MAX_FLAG_CONTENT_LENGTH} chars` });
+  }
+
+  // Self-flagging is not meaningful — reject it.
+  if (flaggedUserId === req.user.id) {
+    return res.status(400).json({ error: 'cannot flag yourself' });
+  }
+
+  let flagId;
+  try {
+    const db = getDb();
+
+    // Verify the flagged user exists and is an analyst (you can only flag analysts
+    // since only analysts participate in peer skill-share). Defense in depth —
+    // the AC UI already filters this, but the server should never trust the client.
+    const flagged = db.prepare("SELECT id, role FROM users WHERE id = ?").get(flaggedUserId);
+    if (!flagged) {
+      db.close();
+      return res.status(404).json({ error: 'flagged user not found' });
+    }
+    if (flagged.role !== 'analyst') {
+      db.close();
+      return res.status(400).json({ error: 'can only flag analysts' });
+    }
+
+    // Encrypt the content. encryptTier3 returns a single Buffer (iv + tag + ciphertext).
+    const ciphertext = encryptTier3(content);
+
+    flagId = crypto.randomBytes(16).toString('hex');
+    const flaggerIp = req.ip || req.connection?.remoteAddress || null;
+
+    db.prepare(`
+      INSERT INTO peer_abuse_flags
+        (id, session_id, flagger_user_id, flagged_user_id, tier, content_encrypted, flagger_ip)
+      VALUES (?, ?, ?, ?, ?, ?, ?)
+    `).run(flagId, sessionId, req.user.id, flaggedUserId, tier, ciphertext, flaggerIp);
+
+    db.close();
+  } catch (err) {
+    logger.error('Failed to insert peer abuse flag', { error: err.message });
+    return res.status(500).json({ error: 'failed to submit flag' });
+  }
+
+  // Notify leads/admins. Recipients are determined by getEligibleRecipients()
+  // in services/notifications.js, which filters by event-type preferences and
+  // honors mandatoryInApp for tier 3.
+  const eventType = `peer_abuse_flag_tier${tier}`;
+  const titleByTier = {
+    1: 'Peer chat — minor conduct flag',
+    2: 'Peer chat — personal attack flag',
+    3: 'Peer chat — URGENT conduct flag',
+  };
+  const bodyByTier = {
+    1: 'An analyst submitted a tier-1 flag for minor conduct issues. Review in the Peer Conduct tab when you have a moment.',
+    2: 'An analyst submitted a tier-2 flag for a personal attack. The flagged peer\'s identity is visible to you. Review the Peer Conduct tab.',
+    3: 'An analyst submitted a tier-3 flag for urgent conduct (slurs, threats, harassment). Both identities are revealed. HR intervention is recommended. Review immediately in the Peer Conduct tab.',
+  };
+
+  // Notify all leads/admins. notify() handles role filtering via EVENT_TYPES
+  // recipients implicit in preferences/registration.
+  try {
+    const db = getDb();
+    const leads = db.prepare("SELECT id FROM users WHERE role IN ('lead', 'admin')").all();
+    db.close();
+    for (const lead of leads) {
+      notifications.notify(eventType, lead.id, {
+        title: titleByTier[tier],
+        body: bodyByTier[tier],
+        linkTab: 'peer_conduct',
+        linkParams: JSON.stringify({ flagId, tier }),
+      }).catch((err) => {
+        logger.error('Failed to deliver peer abuse flag notification', {
+          error: err.message,
+          recipientId: lead.id,
+          tier,
+        });
+      });
+    }
+  } catch (err) {
+    // Notification failure must not undo the flag submission. Log and continue.
+    logger.error('Failed to enumerate notification recipients', { error: err.message });
+  }
+
+  auditLog(req.user.id, 'PEER_ABUSE_FLAG_SUBMITTED', `tier ${tier}, flag ${flagId}`, req.ip);
+
+  return res.status(201).json({
+    id: flagId,
+    tier,
+    createdAt: new Date().toISOString(),
+  });
+});
+
+module.exports = router;

--- a/server/services/notifications.js
+++ b/server/services/notifications.js
@@ -109,6 +109,22 @@ const EVENT_TYPES = {
     default: { in_app: 1, email: 0 },
     description: 'Panic mode has been lifted. Wellness routing is back on and analysts have returned to their previous complexity caps.',
   },
+  peer_abuse_flag_tier1: {
+    label: 'Peer chat — minor conduct flag (tier 1)',
+    default: { in_app: 1, email: 0 },
+    description: 'An analyst flagged a peer skill-share session for minor conduct issues — curt tone, dismissiveness, condescension, mild rudeness. No identity reveal. Aggregated for pattern detection. If a single peer accumulates many tier-1 flags from different reporters, consider a coaching conversation rather than disciplinary action.',
+  },
+  peer_abuse_flag_tier2: {
+    label: 'Peer chat — personal attack flag (tier 2)',
+    default: { in_app: 1, email: 1 },
+    description: 'An analyst flagged a peer skill-share session for direct insult, name-calling, mockery, or demeaning language. Per the peer-chat policy, the flagged peer\'s identity is revealed to you. Flagged content is retained in the secure vault for review. No automatic HR loop — your judgment on next steps.',
+  },
+  peer_abuse_flag_tier3: {
+    label: 'Peer chat — urgent conduct flag (tier 3)',
+    default: { in_app: 1, email: 1 },
+    description: 'An analyst flagged a peer skill-share session for urgent conduct: slurs, explicit threats, sexual harassment, or content suggesting imminent harm. Both the flagged peer\'s identity and the flagger\'s identity are revealed to you. HR intervention is recommended. In-app delivery cannot be turned off for this event.',
+    mandatoryInApp: true,
+  },
 };
 
 function isKnownEventType(eventType) {


### PR DESCRIPTION
## Summary

Phase 1.4b. Replaces the binary "flag abuse" button in peer
skill-share with a three-tier severity system, adds the server
infrastructure to store and review flags, and gives leads a
dedicated Peer Conduct review interface in the MC.

## The three tiers

- **Tier 1 — Minor.** Curt tone, dismissiveness, condescension,
  mild rudeness. Both flagger and flagged stay anonymous.
  Aggregated for pattern detection only — no immediate
  intervention. Surfaces patterns when a single peer accumulates
  many tier-1 flags from different reporters.

- **Tier 2 — Personal attack.** Direct insult, name-calling,
  mockery, demeaning language. Per existing peer-chat policy,
  the flagged peer's identity is revealed to the team lead. The
  flagger stays anonymous. Lead reviews and decides next steps.

- **Tier 3 — Urgent.** Slurs (race, gender, orientation,
  religion, disability), explicit threats, sexual harassment,
  content suggesting imminent harm. Both identities revealed to
  the lead — reciprocal accountability against tier-3 misuse.
  HR intervention recommended. Mandatory in-app delivery via the
  Phase 1.4a notifications system. Dashboard banner persists
  until resolved.

## Server changes

- New table `peer_abuse_flags` (id, session_id, flagger_user_id,
  flagged_user_id, tier, content_encrypted, flagger_ip,
  created_at, resolved_at, resolved_by, resolution_note) with
  AES-256-GCM Tier-3 encryption of flag content
- Three new EVENT_TYPES with tier-3 marked mandatoryInApp
- New routes file `server/routes/peer-flags.js`:
  - POST /api/peer/flags — analyst submits flag
  - GET /api/peer/flags — lead/admin lists with status and tier
    filters; identity reveal applied at response time per tier
  - POST /api/peer/flags/:id/resolve — lead/admin resolves with
    optional note
- Mounted at /api/peer/flags with auth for analyst/lead/admin

## Frontend changes

**AC (analyst-client.jsx):**
- Single "I need to flag abusive language" button replaced with
  a 3-tier radio picker
- Each tier shows its identity-reveal policy explicitly so
  analysts calibrate correctly
- Submit button disabled until both tier and content set
- Server endpoint wiring left as TODO — peer chat is still
  client-side, so there's no real session ID yet. Flags still
  recorded in the AC audit trail so they aren't lost

**MC (firealive-mc.jsx):**
- New Peer Conduct tab in the Operations nav group between Inbox
  and Actions, with badge showing total open flag count
- Tier-color-coded flag cards (red urgent, amber attack, blue
  minor) sorted by tier descending then created descending
- Status filter (Open / Resolved / All) and tier filter
- Tier-3 cards include "HR intervention recommended" callout
- Resolve workflow: Mark Resolved → 2000-char note textarea →
  Submit Resolution
- 60s polling for open count and urgent open count from a single
  GET request
- Dashboard-level red banner appears whenever tier-3 open flags
  exist, visible on every screen until resolved. Clicking the
  banner navigates to Peer Conduct.

## Commits

1. `db: add peer_abuse_flags table for tiered abuse flagging`
2. `notifications: add tier1/tier2/tier3 peer abuse flag event types`
3. `peer-flags: add POST /api/peer/flags route for tiered abuse flag submission`
4. `server: register /api/peer/flags route`
5. `peer-flags: add GET list and POST resolve handlers with tier-based identity reveal`
6. `ac(peer-flags): replace single flag button with 3-tier severity picker`
7. `mc(peer-conduct): add Peer Conduct tab with tier-filtered flag list and resolve workflow`
8. `mc(peer-conduct): add tier-3 unresolved-flag dashboard banner`

(Plus one fix-up to commit 1 simplifying the ciphertext column
to match the encryption helper's single-blob output.)

## Pairs with

The package.json bump to v1.0.11 + fuseCounter 4 will go in a
separate small PR after this one merges, alongside the README
update. Same pattern as v1.0.10.

## Out of scope (future PRs)

- Wiring AC flag​​​​​​​​​​​​​​​​