### PR TITLE
v1.0.11 — Tiered abuse flagging release tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # FireAlive — SOC Analyst Wellbeing Platform
 
-**Version:** v1.0.10 | **License:** AGPL-3.0-or-later | **Author:** Peter Mancina   
-**E-fuse counter:** 3 (anti-rollback)
+**Version:** v1.0.11 | **License:** AGPL-3.0-or-later | **Author:** Peter Mancina   
+**E-fuse counter:** 4 (anti-rollback)
 
 ---
 
@@ -68,7 +68,7 @@ All endpoints require JWT authentication. Manager-only endpoints enforce RBAC.
 
 > **⚠️ Pre-Release Notice:** FireAlive is in pre-release. It should be evaluated in a lab or sandbox environment before any production deployment. SOC teams should thoroughly test all integrations, routing logic, and security controls in a non-production setting before relying on FireAlive for operational use. Community testing, feedback, and contributions are welcome.
 
-**Download installers:** Pre-built installers for Mac (.dmg), Windows (.exe), and Linux (.AppImage) are available on the [Releases page](https://github.com/petermancina/firealive/releases/tag/v1.0.10) under Tags.
+**Download installers:** Pre-built installers for Mac (.dmg), Windows (.exe), and Linux (.AppImage) are available on the [Releases page](https://github.com/petermancina/firealive/releases/tag/v1.0.11) under Tags.
 
 See **SETUP.md** for detailed setup instructions.
 

--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
   "name": "firealive",
-  "version": "1.0.10",
-  "fuseCounter": 3,
-  "buildId": "20260430.1",
+  "version": "1.0.11",
+  "fuseCounter": 4,
+    "buildId": "20260501.1",
   "description": "FireAlive — SOC Analyst Wellbeing Platform. Burnout-aware ticket routing, peer skill-share, post-incident wellness, skills assessments, and team health monitoring with privacy-first architecture.",
   "main": "server/index.js",
   "directories": {


### PR DESCRIPTION
## Summary

Tags v1.0.11. Bumps package.json (version 1.0.10 → 1.0.11,
fuseCounter 3 → 4, buildId 20260430.1 → 20260501.1) and refreshes
the README's version block.

The substantive Phase 1.4b work — tiered abuse flagging in peer
skill-share — already merged in PR `phase-1.4b-tiered-abuse-flagging`.
This release-tag PR is the final step that publishes 1.0.11 as a
discrete release.

## What 1.0.11 ships

Phase 1.4b tiered abuse flagging:
- Three tiers (minor / personal attack / urgent) replace the
  binary "flag abuse" button in peer skill-share
- Tier-based identity reveal: tier 1 anonymous, tier 2 reveals
  flagged peer, tier 3 reveals both for reciprocal accountability
- Server-side `peer_abuse_flags` table with AES-256-GCM Tier-3
  encryption of flag content
- Three new EVENT_TYPES with mandatory in-app delivery for tier 3
- Server routes: POST /api/peer/flags, GET /api/peer/flags,
  POST /api/peer/flags/:id/resolve
- New MC Peer Conduct tab with tier-color-coded flag list,
  status/tier filters, and resolve workflow
- Tier-3 dashboard banner that persists across all MC screens
  until the urgent flag is resolved
- AC tier picker UI replacing the single submit button

## Commits

1. `chore: bump version to 1.0.11, fuseCounter 4, buildId 20260501.1`
2. `docs: bump README to v1.0.11 and fuse counter 4`

## After merge

Tag the release on GitHub Releases page with tag `v1.0.11` and a
release description summarizing Phase 1.4b. Then we move on to
Phase 1.4c — IR Recovery Runbook (org-policy-driven).
