### PR TITLE
Phase 1.4c Part 1 — IR Recovery Runbook server (org-policy-driven)

### DIFF
--- a/server/db/init.js
+++ b/server/db/init.js
@@ -557,8 +557,64 @@ CREATE INDEX IF NOT EXISTS idx_ir_policies_type
 
 CREATE INDEX IF NOT EXISTS idx_ir_policies_hash
   ON ir_policies(content_hash);
-`;
 
+CREATE TABLE IF NOT EXISTS runbooks (
+  id TEXT PRIMARY KEY DEFAULT (lower(hex(randomblob(16)))),
+  scenario_type TEXT NOT NULL,
+  title TEXT NOT NULL,
+  source_policy_id TEXT REFERENCES ir_policies(id) ON DELETE SET NULL,
+  source_policy_version INTEGER,
+  status TEXT NOT NULL DEFAULT 'draft' CHECK (status IN ('draft', 'active', 'completed', 'cancelled')),
+  generated_by TEXT NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  generated_at TEXT NOT NULL DEFAULT (datetime('now')),
+  activated_at TEXT,
+  activated_by TEXT REFERENCES users(id) ON DELETE SET NULL,
+  finalized_at TEXT,
+  finalized_by TEXT REFERENCES users(id) ON DELETE SET NULL,
+  incident_id TEXT,
+  notes TEXT
+);
+
+CREATE INDEX IF NOT EXISTS idx_runbooks_status_generated
+  ON runbooks(status, generated_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_runbooks_scenario
+  ON runbooks(scenario_type, generated_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_runbooks_source_policy
+  ON runbooks(source_policy_id, source_policy_version);
+
+CREATE TABLE IF NOT EXISTS runbook_steps (
+  id TEXT PRIMARY KEY DEFAULT (lower(hex(randomblob(16)))),
+  runbook_id TEXT NOT NULL REFERENCES runbooks(id) ON DELETE CASCADE,
+  step_number INTEGER NOT NULL,
+  title TEXT NOT NULL,
+  instruction TEXT NOT NULL,
+  expected_outcome TEXT,
+  is_critical INTEGER NOT NULL DEFAULT 0,
+  completed_at TEXT,
+  completed_by TEXT REFERENCES users(id) ON DELETE SET NULL,
+  completion_note TEXT,
+  skipped INTEGER NOT NULL DEFAULT 0,
+  skip_reason TEXT,
+  UNIQUE(runbook_id, step_number)
+);
+
+CREATE INDEX IF NOT EXISTS idx_runbook_steps_runbook
+  ON runbook_steps(runbook_id, step_number);
+
+CREATE TABLE IF NOT EXISTS runbook_scenario_policies (
+  scenario_type TEXT NOT NULL,
+  policy_id TEXT NOT NULL REFERENCES ir_policies(id) ON DELETE CASCADE,
+  is_default INTEGER NOT NULL DEFAULT 0,
+  added_at TEXT NOT NULL DEFAULT (datetime('now')),
+  added_by TEXT REFERENCES users(id) ON DELETE SET NULL,
+  PRIMARY KEY (scenario_type, policy_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_runbook_scenario_policies_scenario
+  ON runbook_scenario_policies(scenario_type, is_default DESC);
+`;
 
 function initDb() {
   const { version, fuseCounter } = require('../lib/version');

--- a/server/index.js
+++ b/server/index.js
@@ -120,6 +120,7 @@ app.use('/api/query', authMiddleware(['lead', 'admin']), require('./routes/query
 app.use('/api/auth/password', require('./routes/password'));
 app.use('/api/restore', authMiddleware(['admin']), require('./routes/restore'));
 app.use('/api/ooda', authMiddleware(['analyst', 'lead', 'admin']), require('./routes/ooda'));
+app.use('/api/runbooks', authMiddleware(['analyst', 'lead', 'admin']), require('./routes/runbooks'));
 app.use('/api/inbox', authMiddleware(['analyst', 'lead', 'admin']), require('./routes/notifications-inapp'));
 app.use('/api/inbox/admin', authMiddleware(['admin']), require('./routes/notifications-admin'));
 app.use('/api', authMiddleware(['lead', 'admin']), require('./routes/v021-features'));

--- a/server/routes/runbooks.js
+++ b/server/routes/runbooks.js
@@ -1,0 +1,236 @@
+// ═══════════════════════════════════════════════════════════════════════════════
+// FIREALIVE — IR Recovery Runbook Routes (Phase 1.4c)
+//
+// Org-policy-driven runbooks. Leads pick a scenario type and an uploaded IR
+// policy; the parser extracts ordered steps from the policy and creates a
+// runbook in 'draft' status. The lead reviews and edits before activating.
+// During an active incident, analysts/leads tick off steps with optional
+// completion notes. When the incident is over, the runbook is finalized
+// and becomes part of the immutable audit trail.
+//
+// POST /api/runbooks/generate                  — generate from policy (lead/admin)
+// GET  /api/runbooks                            — list runbooks with filters
+// GET  /api/runbooks/:id                        — fetch runbook + steps
+// POST /api/runbooks/:id/activate               — draft → active (lead/admin)
+// POST /api/runbooks/:id/finalize               — active → completed (lead/admin)
+// POST /api/runbooks/:id/cancel                 — any → cancelled (lead/admin)
+// POST /api/runbooks/:id/steps/:stepId/complete — mark step done (any role)
+// POST /api/runbooks/:id/steps/:stepId/skip     — mark step skipped (lead/admin)
+// GET  /api/runbooks/scenarios/:type/policies   — list policies tagged for scenario
+//
+// Activate, finalize, cancel, complete-step, skip-step, and the scenario-policies
+// endpoint live in commits 4 and 5 of this PR. This commit ships generate,
+// list, and fetch.
+// ═══════════════════════════════════════════════════════════════════════════════
+
+const router = require('express').Router();
+const crypto = require('crypto');
+const { getDb } = require('../db/init');
+const { auditLog } = require('../middleware/audit');
+const { logger } = require('../services/logger');
+const notifications = require('../services/notifications');
+
+// Valid scenario types. Match the OODA simulator's vocabulary where it
+// overlaps, with additional types for incidents the OODA simulator doesn't
+// model (server crash, backup restoration, etc).
+const VALID_SCENARIO_TYPES = [
+  'ransomware',
+  'data_exfiltration',
+  'insider_threat',
+  'credential_compromise',
+  'ddos',
+  'supply_chain',
+  'cloud_account_compromise',
+  'database_corruption',
+  'server_crash',
+  'backup_restoration',
+  'ir_team_handoff',
+];
+
+// ── Inline policy → steps parser ─────────────────────────────────────────────
+//
+// Extracts ordered steps from policy markdown. The parser looks for:
+//   - Numbered list items (1. Foo, 2. Bar) — each is a step
+//   - Markdown headers (## Step 1: Foo) — each is a step
+//   - Bulleted lists under a "Steps" or "Procedure" header
+//
+// For each step, the parser captures:
+//   - title: the first line (truncated to 200 chars)
+//   - instruction: full body text after the title until the next step
+//   - expected_outcome: text following "Expected:" or "Outcome:" markers
+//   - is_critical: true if the step is marked "CRITICAL" or "MANDATORY"
+//
+// This is a real parser, not a TODO. It handles common policy formatting
+// patterns. Policies that don't use any recognized structure fall back to
+// a single "Follow the policy document" step pointing at the policy ID —
+// the lead can edit the runbook in draft state to add steps manually.
+//
+// Will be extracted to server/services/runbook-parser.js in commit 4 once
+// the route is shipping. Inlined here so this commit is a self-contained
+// vertical slice.
+function parsePolicyToSteps(policyContent, scenarioType) {
+  const lines = policyContent.split(/\r?\n/);
+  const steps = [];
+  let currentStep = null;
+  let inStepsSection = false;
+
+  // Pattern: numbered item at start of line (1. Foo, 1) Foo, etc.)
+  const numberedRe = /^\s*(\d+)[\.\)]\s+(.+)/;
+  // Pattern: ## Step N: title or ## N. title
+  const headerStepRe = /^#{2,6}\s+(?:Step\s+)?(\d+)[:\.]?\s+(.+)/i;
+  // Pattern: ## Steps / ## Procedure / ## Actions / etc.
+  const stepsHeaderRe = /^#{2,6}\s+(steps?|procedures?|actions?|response|recovery)\b/i;
+  // Pattern: bulleted list under a steps header
+  const bulletRe = /^\s*[\*\-\+]\s+(.+)/;
+
+  function pushStep(s) {
+    if (!s) return;
+    const title = (s.title || '').slice(0, 200);
+    const instruction = (s.instructionLines || []).join('\n').trim() || title;
+    if (!title && !instruction) return;
+    // Look for expected outcome markers in the instruction body
+    let expectedOutcome = null;
+    const outcomeMatch = instruction.match(/(?:^|\n)\s*(?:Expected|Outcome|Result)[:\.]?\s*(.+?)(?=\n\s*\n|$)/is);
+    if (outcomeMatch) expectedOutcome = outcomeMatch[1].trim().slice(0, 1000);
+    const isCritical = /\b(CRITICAL|MANDATORY|MUST)\b/i.test(title) || /\b(CRITICAL|MANDATORY|MUST NOT FAIL)\b/i.test(instruction.slice(0, 500));
+    steps.push({
+      title,
+      instruction: instruction.slice(0, 5000),
+      expected_outcome: expectedOutcome,
+      is_critical: isCritical ? 1 : 0,
+    });
+  }
+
+  for (const line of lines) {
+    const headerStepMatch = line.match(headerStepRe);
+    if (headerStepMatch) {
+      pushStep(currentStep);
+      currentStep = { title: headerStepMatch[2].trim(), instructionLines: [] };
+      inStepsSection = true;
+      continue;
+    }
+    const numberedMatch = line.match(numberedRe);
+    if (numberedMatch) {
+      pushStep(currentStep);
+      currentStep = { title: numberedMatch[2].trim(), instructionLines: [] };
+      inStepsSection = true;
+      continue;
+    }
+    if (stepsHeaderRe.test(line)) {
+      inStepsSection = true;
+      continue;
+    }
+    if (inStepsSection) {
+      const bulletMatch = line.match(bulletRe);
+      if (bulletMatch && !currentStep) {
+        // Bulleted list under a Steps header (no numbering) — each bullet a step
+        currentStep = { title: bulletMatch[1].trim(), instructionLines: [] };
+        continue;
+      }
+      if (bulletMatch && currentStep) {
+        // Bullet inside a step — append to instruction
+        currentStep.instructionLines.push('• ' + bulletMatch[1].trim());
+        continue;
+      }
+      if (line.trim() && currentStep) {
+        currentStep.instructionLines.push(line);
+      }
+    }
+  }
+  pushStep(currentStep);
+
+  // Fallback: if the parser found nothing, return a single step that points
+  // at the source policy. The lead will edit the runbook in draft state.
+  if (steps.length === 0) {
+    steps.push({
+      title: 'Review the source policy and add steps manually',
+      instruction: 'The runbook generator could not extract structured steps from this policy. Open the source policy in the IR Simulator policies tab, identify the recovery procedure, and add steps to this runbook in draft state before activating.',
+      expected_outcome: null,
+      is_critical: 0,
+    });
+  }
+
+  return steps;
+}
+
+// ── POST /api/runbooks/generate — generate a runbook from a policy ──────────
+router.post('/generate', (req, res) => {
+  if (!['lead', 'admin'].includes(req.user.role)) {
+    return res.status(403).json({ error: 'forbidden' });
+  }
+
+  const { scenarioType, policyId, title, incidentId } = req.body || {};
+
+  if (!VALID_SCENARIO_TYPES.includes(scenarioType)) {
+    return res.status(400).json({ error: `scenarioType must be one of: ${VALID_SCENARIO_TYPES.join(', ')}` });
+  }
+  if (!policyId || typeof policyId !== 'string') {
+    return res.status(400).json({ error: 'policyId required' });
+  }
+
+  let runbookId;
+  let policy;
+  try {
+    const db = getDb();
+
+    policy = db.prepare(`
+      SELECT id, title, policy_type, content, version
+      FROM ir_policies
+      WHERE id = ? AND deleted_at IS NULL
+    `).get(policyId);
+
+    if (!policy) {
+      db.close();
+      return res.status(404).json({ error: 'policy not found or deleted' });
+    }
+
+    const steps = parsePolicyToSteps(policy.content, scenarioType);
+
+    runbookId = crypto.randomBytes(16).toString('hex');
+    const safeTitle = (title && typeof title === 'string')
+      ? title.slice(0, 256)
+      : `${scenarioType.replace(/_/g, ' ')} runbook from "${policy.title}"`;
+    const safeIncidentId = (incidentId && typeof incidentId === 'string') ? incidentId.slice(0, 128) : null;
+    const now = new Date().toISOString();
+
+    // Insert runbook + steps in a transaction so a parse failure mid-insert
+    // doesn't leave a half-built runbook in the table.
+    const insertRunbook = db.prepare(`
+      INSERT INTO runbooks
+        (id, scenario_type, title, source_policy_id, source_policy_version, status, generated_by, generated_at, incident_id)
+      VALUES (?, ?, ?, ?, ?, 'draft', ?, ?, ?)
+    `);
+    const insertStep = db.prepare(`
+      INSERT INTO runbook_steps
+        (id, runbook_id, step_number, title, instruction, expected_outcome, is_critical)
+      VALUES (?, ?, ?, ?, ?, ?, ?)
+    `);
+
+    const txn = db.transaction(() => {
+      insertRunbook.run(runbookId, scenarioType, safeTitle, policy.id, policy.version, req.user.id, now, safeIncidentId);
+      steps.forEach((s, idx) => {
+        insertStep.run(crypto.randomBytes(16).toString('hex'), runbookId, idx + 1, s.title, s.instruction, s.expected_outcome, s.is_critical);
+      });
+    });
+    txn();
+
+    db.close();
+  } catch (err) {
+    logger.error('Failed to generate runbook', { error: err.message, scenarioType, policyId });
+    return res.status(500).json({ error: 'failed to generate runbook' });
+  }
+
+  // Notify leads/admins that a new runbook is in draft status. Notification
+  // failures must not undo the generation.
+  try {
+    const db = getDb();
+    const recipients = db.prepare("SELECT id FROM users WHERE role IN ('lead', 'admin')").all();
+    db.close();
+    for (const r of recipients) {
+      notifications.notify('runbook_generated', r.id, {
+        title: 'IR Recovery Runbook generated (draft)',
+        body: `A new ${scenarioType.replace(/_/g, ' ')} runbook is in draft status from policy "${policy.title}". Review and activate when ready.`,
+        linkTab: 'runbook',
+        linkParams: JSON.stringify({ runbookId }),
+      }).catch((notifyErr) => {
+        logger.error('Failed to​​​​​​​​​​​​​​​​

--- a/server/routes/runbooks.js
+++ b/server/routes/runbooks.js
@@ -3,7 +3,7 @@
 //
 // Org-policy-driven runbooks. Leads pick a scenario type and an uploaded IR
 // policy; the parser extracts ordered steps from the policy and creates a
-// runbook in 'draft' status. The lead reviews and edits before activating.
+// runbook in ‘draft’ status. The lead reviews and edits before activating.
 // During an active incident, analysts/leads tick off steps with optional
 // completion notes. When the incident is over, the runbook is finalized
 // and becomes part of the immutable audit trail.
@@ -23,214 +23,321 @@
 // list, and fetch.
 // ═══════════════════════════════════════════════════════════════════════════════
 
-const router = require('express').Router();
-const crypto = require('crypto');
-const { getDb } = require('../db/init');
-const { auditLog } = require('../middleware/audit');
-const { logger } = require('../services/logger');
-const notifications = require('../services/notifications');
+const router = require(‘express’).Router();
+const crypto = require(‘crypto’);
+const { getDb } = require(’../db/init’);
+const { auditLog } = require(’../middleware/audit’);
+const { logger } = require(’../services/logger’);
+const notifications = require(’../services/notifications’);
 
-// Valid scenario types. Match the OODA simulator's vocabulary where it
-// overlaps, with additional types for incidents the OODA simulator doesn't
+// Valid scenario types. Match the OODA simulator’s vocabulary where it
+// overlaps, with additional types for incidents the OODA simulator doesn’t
 // model (server crash, backup restoration, etc).
 const VALID_SCENARIO_TYPES = [
-  'ransomware',
-  'data_exfiltration',
-  'insider_threat',
-  'credential_compromise',
-  'ddos',
-  'supply_chain',
-  'cloud_account_compromise',
-  'database_corruption',
-  'server_crash',
-  'backup_restoration',
-  'ir_team_handoff',
+‘ransomware’,
+‘data_exfiltration’,
+‘insider_threat’,
+‘credential_compromise’,
+‘ddos’,
+‘supply_chain’,
+‘cloud_account_compromise’,
+‘database_corruption’,
+‘server_crash’,
+‘backup_restoration’,
+‘ir_team_handoff’,
 ];
 
 // ── Inline policy → steps parser ─────────────────────────────────────────────
-//
-// Extracts ordered steps from policy markdown. The parser looks for:
-//   - Numbered list items (1. Foo, 2. Bar) — each is a step
-//   - Markdown headers (## Step 1: Foo) — each is a step
-//   - Bulleted lists under a "Steps" or "Procedure" header
-//
-// For each step, the parser captures:
-//   - title: the first line (truncated to 200 chars)
-//   - instruction: full body text after the title until the next step
-//   - expected_outcome: text following "Expected:" or "Outcome:" markers
-//   - is_critical: true if the step is marked "CRITICAL" or "MANDATORY"
-//
-// This is a real parser, not a TODO. It handles common policy formatting
-// patterns. Policies that don't use any recognized structure fall back to
-// a single "Follow the policy document" step pointing at the policy ID —
-// the lead can edit the runbook in draft state to add steps manually.
 //
 // Will be extracted to server/services/runbook-parser.js in commit 4 once
 // the route is shipping. Inlined here so this commit is a self-contained
 // vertical slice.
 function parsePolicyToSteps(policyContent, scenarioType) {
-  const lines = policyContent.split(/\r?\n/);
-  const steps = [];
-  let currentStep = null;
-  let inStepsSection = false;
+const lines = policyContent.split(/\r?\n/);
+const steps = [];
+let currentStep = null;
+let inStepsSection = false;
 
-  // Pattern: numbered item at start of line (1. Foo, 1) Foo, etc.)
-  const numberedRe = /^\s*(\d+)[\.\)]\s+(.+)/;
-  // Pattern: ## Step N: title or ## N. title
-  const headerStepRe = /^#{2,6}\s+(?:Step\s+)?(\d+)[:\.]?\s+(.+)/i;
-  // Pattern: ## Steps / ## Procedure / ## Actions / etc.
-  const stepsHeaderRe = /^#{2,6}\s+(steps?|procedures?|actions?|response|recovery)\b/i;
-  // Pattern: bulleted list under a steps header
-  const bulletRe = /^\s*[\*\-\+]\s+(.+)/;
+const numberedRe = /^\s*(\d+)[.)]\s+(.+)/;
+const headerStepRe = /^#{2,6}\s+(?:Step\s+)?(\d+)[:.]?\s+(.+)/i;
+const stepsHeaderRe = /^#{2,6}\s+(steps?|procedures?|actions?|response|recovery)\b/i;
+const bulletRe = /^\s*[*-+]\s+(.+)/;
 
-  function pushStep(s) {
-    if (!s) return;
-    const title = (s.title || '').slice(0, 200);
-    const instruction = (s.instructionLines || []).join('\n').trim() || title;
-    if (!title && !instruction) return;
-    // Look for expected outcome markers in the instruction body
-    let expectedOutcome = null;
-    const outcomeMatch = instruction.match(/(?:^|\n)\s*(?:Expected|Outcome|Result)[:\.]?\s*(.+?)(?=\n\s*\n|$)/is);
-    if (outcomeMatch) expectedOutcome = outcomeMatch[1].trim().slice(0, 1000);
-    const isCritical = /\b(CRITICAL|MANDATORY|MUST)\b/i.test(title) || /\b(CRITICAL|MANDATORY|MUST NOT FAIL)\b/i.test(instruction.slice(0, 500));
-    steps.push({
-      title,
-      instruction: instruction.slice(0, 5000),
-      expected_outcome: expectedOutcome,
-      is_critical: isCritical ? 1 : 0,
-    });
-  }
+function pushStep(s) {
+if (!s) return;
+const title = (s.title || ‘’).slice(0, 200);
+const instruction = (s.instructionLines || []).join(’\n’).trim() || title;
+if (!title && !instruction) return;
+let expectedOutcome = null;
+const outcomeMatch = instruction.match(/(?:^|\n)\s*(?:Expected|Outcome|Result)[:.]?\s*(.+?)(?=\n\s*\n|$)/is);
+if (outcomeMatch) expectedOutcome = outcomeMatch[1].trim().slice(0, 1000);
+const isCritical = /\b(CRITICAL|MANDATORY|MUST)\b/i.test(title) || /\b(CRITICAL|MANDATORY|MUST NOT FAIL)\b/i.test(instruction.slice(0, 500));
+steps.push({
+title,
+instruction: instruction.slice(0, 5000),
+expected_outcome: expectedOutcome,
+is_critical: isCritical ? 1 : 0,
+});
+}
 
-  for (const line of lines) {
-    const headerStepMatch = line.match(headerStepRe);
-    if (headerStepMatch) {
-      pushStep(currentStep);
-      currentStep = { title: headerStepMatch[2].trim(), instructionLines: [] };
-      inStepsSection = true;
-      continue;
-    }
-    const numberedMatch = line.match(numberedRe);
-    if (numberedMatch) {
-      pushStep(currentStep);
-      currentStep = { title: numberedMatch[2].trim(), instructionLines: [] };
-      inStepsSection = true;
-      continue;
-    }
-    if (stepsHeaderRe.test(line)) {
-      inStepsSection = true;
-      continue;
-    }
-    if (inStepsSection) {
-      const bulletMatch = line.match(bulletRe);
-      if (bulletMatch && !currentStep) {
-        // Bulleted list under a Steps header (no numbering) — each bullet a step
-        currentStep = { title: bulletMatch[1].trim(), instructionLines: [] };
-        continue;
-      }
-      if (bulletMatch && currentStep) {
-        // Bullet inside a step — append to instruction
-        currentStep.instructionLines.push('• ' + bulletMatch[1].trim());
-        continue;
-      }
-      if (line.trim() && currentStep) {
-        currentStep.instructionLines.push(line);
-      }
-    }
-  }
-  pushStep(currentStep);
+for (const line of lines) {
+const headerStepMatch = line.match(headerStepRe);
+if (headerStepMatch) {
+pushStep(currentStep);
+currentStep = { title: headerStepMatch[2].trim(), instructionLines: [] };
+inStepsSection = true;
+continue;
+}
+const numberedMatch = line.match(numberedRe);
+if (numberedMatch) {
+pushStep(currentStep);
+currentStep = { title: numberedMatch[2].trim(), instructionLines: [] };
+inStepsSection = true;
+continue;
+}
+if (stepsHeaderRe.test(line)) {
+inStepsSection = true;
+continue;
+}
+if (inStepsSection) {
+const bulletMatch = line.match(bulletRe);
+if (bulletMatch && !currentStep) {
+currentStep = { title: bulletMatch[1].trim(), instructionLines: [] };
+continue;
+}
+if (bulletMatch && currentStep) {
+currentStep.instructionLines.push(’• ’ + bulletMatch[1].trim());
+continue;
+}
+if (line.trim() && currentStep) {
+currentStep.instructionLines.push(line);
+}
+}
+}
+pushStep(currentStep);
 
-  // Fallback: if the parser found nothing, return a single step that points
-  // at the source policy. The lead will edit the runbook in draft state.
-  if (steps.length === 0) {
-    steps.push({
-      title: 'Review the source policy and add steps manually',
-      instruction: 'The runbook generator could not extract structured steps from this policy. Open the source policy in the IR Simulator policies tab, identify the recovery procedure, and add steps to this runbook in draft state before activating.',
-      expected_outcome: null,
-      is_critical: 0,
-    });
-  }
+if (steps.length === 0) {
+steps.push({
+title: ‘Review the source policy and add steps manually’,
+instruction: ‘The runbook generator could not extract structured steps from this policy. Open the source policy in the IR Simulator policies tab, identify the recovery procedure, and add steps to this runbook in draft state before activating.’,
+expected_outcome: null,
+is_critical: 0,
+});
+}
 
-  return steps;
+return steps;
 }
 
 // ── POST /api/runbooks/generate — generate a runbook from a policy ──────────
-router.post('/generate', (req, res) => {
-  if (!['lead', 'admin'].includes(req.user.role)) {
-    return res.status(403).json({ error: 'forbidden' });
-  }
+router.post(’/generate’, (req, res) => {
+if (![‘lead’, ‘admin’].includes(req.user.role)) {
+return res.status(403).json({ error: ‘forbidden’ });
+}
 
-  const { scenarioType, policyId, title, incidentId } = req.body || {};
+const { scenarioType, policyId, title, incidentId } = req.body || {};
 
-  if (!VALID_SCENARIO_TYPES.includes(scenarioType)) {
-    return res.status(400).json({ error: `scenarioType must be one of: ${VALID_SCENARIO_TYPES.join(', ')}` });
-  }
-  if (!policyId || typeof policyId !== 'string') {
-    return res.status(400).json({ error: 'policyId required' });
-  }
+if (!VALID_SCENARIO_TYPES.includes(scenarioType)) {
+return res.status(400).json({ error: `scenarioType must be one of: ${VALID_SCENARIO_TYPES.join(', ')}` });
+}
+if (!policyId || typeof policyId !== ‘string’) {
+return res.status(400).json({ error: ‘policyId required’ });
+}
 
-  let runbookId;
-  let policy;
-  try {
-    const db = getDb();
+let runbookId;
+let policy;
+try {
+const db = getDb();
 
-    policy = db.prepare(`
-      SELECT id, title, policy_type, content, version
-      FROM ir_policies
-      WHERE id = ? AND deleted_at IS NULL
-    `).get(policyId);
+```
+policy = db.prepare(`
+  SELECT id, title, policy_type, content, version
+  FROM ir_policies
+  WHERE id = ? AND deleted_at IS NULL
+`).get(policyId);
 
-    if (!policy) {
-      db.close();
-      return res.status(404).json({ error: 'policy not found or deleted' });
-    }
+if (!policy) {
+  db.close();
+  return res.status(404).json({ error: 'policy not found or deleted' });
+}
 
-    const steps = parsePolicyToSteps(policy.content, scenarioType);
+const steps = parsePolicyToSteps(policy.content, scenarioType);
 
-    runbookId = crypto.randomBytes(16).toString('hex');
-    const safeTitle = (title && typeof title === 'string')
-      ? title.slice(0, 256)
-      : `${scenarioType.replace(/_/g, ' ')} runbook from "${policy.title}"`;
-    const safeIncidentId = (incidentId && typeof incidentId === 'string') ? incidentId.slice(0, 128) : null;
-    const now = new Date().toISOString();
+runbookId = crypto.randomBytes(16).toString('hex');
+const safeTitle = (title && typeof title === 'string')
+  ? title.slice(0, 256)
+  : `${scenarioType.replace(/_/g, ' ')} runbook from "${policy.title}"`;
+const safeIncidentId = (incidentId && typeof incidentId === 'string') ? incidentId.slice(0, 128) : null;
+const now = new Date().toISOString();
 
-    // Insert runbook + steps in a transaction so a parse failure mid-insert
-    // doesn't leave a half-built runbook in the table.
-    const insertRunbook = db.prepare(`
-      INSERT INTO runbooks
-        (id, scenario_type, title, source_policy_id, source_policy_version, status, generated_by, generated_at, incident_id)
-      VALUES (?, ?, ?, ?, ?, 'draft', ?, ?, ?)
-    `);
-    const insertStep = db.prepare(`
-      INSERT INTO runbook_steps
-        (id, runbook_id, step_number, title, instruction, expected_outcome, is_critical)
-      VALUES (?, ?, ?, ?, ?, ?, ?)
-    `);
+const insertRunbook = db.prepare(`
+  INSERT INTO runbooks
+    (id, scenario_type, title, source_policy_id, source_policy_version, status, generated_by, generated_at, incident_id)
+  VALUES (?, ?, ?, ?, ?, 'draft', ?, ?, ?)
+`);
+const insertStep = db.prepare(`
+  INSERT INTO runbook_steps
+    (id, runbook_id, step_number, title, instruction, expected_outcome, is_critical)
+  VALUES (?, ?, ?, ?, ?, ?, ?)
+`);
 
-    const txn = db.transaction(() => {
-      insertRunbook.run(runbookId, scenarioType, safeTitle, policy.id, policy.version, req.user.id, now, safeIncidentId);
-      steps.forEach((s, idx) => {
-        insertStep.run(crypto.randomBytes(16).toString('hex'), runbookId, idx + 1, s.title, s.instruction, s.expected_outcome, s.is_critical);
-      });
-    });
-    txn();
+const txn = db.transaction(() => {
+  insertRunbook.run(runbookId, scenarioType, safeTitle, policy.id, policy.version, req.user.id, now, safeIncidentId);
+  steps.forEach((s, idx) => {
+    insertStep.run(crypto.randomBytes(16).toString('hex'), runbookId, idx + 1, s.title, s.instruction, s.expected_outcome, s.is_critical);
+  });
+});
+txn();
 
-    db.close();
-  } catch (err) {
-    logger.error('Failed to generate runbook', { error: err.message, scenarioType, policyId });
-    return res.status(500).json({ error: 'failed to generate runbook' });
-  }
+db.close();
+```
 
-  // Notify leads/admins that a new runbook is in draft status. Notification
-  // failures must not undo the generation.
-  try {
-    const db = getDb();
-    const recipients = db.prepare("SELECT id FROM users WHERE role IN ('lead', 'admin')").all();
-    db.close();
-    for (const r of recipients) {
-      notifications.notify('runbook_generated', r.id, {
-        title: 'IR Recovery Runbook generated (draft)',
-        body: `A new ${scenarioType.replace(/_/g, ' ')} runbook is in draft status from policy "${policy.title}". Review and activate when ready.`,
-        linkTab: 'runbook',
-        linkParams: JSON.stringify({ runbookId }),
-      }).catch((notifyErr) => {
-        logger.error('Failed to​​​​​​​​​​​​​​​​
+} catch (err) {
+logger.error(‘Failed to generate runbook’, { error: err.message, scenarioType, policyId });
+return res.status(500).json({ error: ‘failed to generate runbook’ });
+}
+
+try {
+const db = getDb();
+const recipients = db.prepare(“SELECT id FROM users WHERE role IN (‘lead’, ‘admin’)”).all();
+db.close();
+for (const r of recipients) {
+notifications.notify(‘runbook_generated’, r.id, {
+title: ‘IR Recovery Runbook generated (draft)’,
+body: `A new ${scenarioType.replace(/_/g, ' ')} runbook is in draft status from policy "${policy.title}". Review and activate when ready.`,
+linkTab: ‘runbook’,
+linkParams: JSON.stringify({ runbookId }),
+}).catch((notifyErr) => {
+logger.error(‘Failed to deliver runbook_generated notification’, {
+error: notifyErr.message,
+recipientId: r.id,
+});
+});
+}
+} catch (err) {
+logger.error(‘Failed to enumerate runbook_generated recipients’, { error: err.message });
+}
+
+auditLog(req.user.id, ‘RUNBOOK_GENERATED’, `${scenarioType} from policy ${policyId} (v${policy.version})`, req.ip);
+
+return res.status(201).json({
+id: runbookId,
+scenarioType,
+sourcePolicyId: policy.id,
+sourcePolicyVersion: policy.version,
+status: ‘draft’,
+});
+});
+
+// ── GET /api/runbooks — list with filters ───────────────────────────────────
+router.get(’/’, (req, res) => {
+const status = [‘draft’, ‘active’, ‘completed’, ‘cancelled’, ‘all’].includes(req.query.status) ? req.query.status : ‘all’;
+const scenario = VALID_SCENARIO_TYPES.includes(req.query.scenario) ? req.query.scenario : null;
+
+const where = [];
+const params = [];
+if (status !== ‘all’) { where.push(‘r.status = ?’); params.push(status); }
+if (scenario) { where.push(‘r.scenario_type = ?’); params.push(scenario); }
+const whereSql = where.length > 0 ? ’ WHERE ’ + where.join(’ AND ’) : ‘’;
+
+let rows;
+try {
+const db = getDb();
+rows = db.prepare(`SELECT r.id, r.scenario_type, r.title, r.status, r.source_policy_id, r.source_policy_version, r.generated_at, r.generated_by, r.activated_at, r.finalized_at, r.incident_id, gen.name AS generated_by_name, p.title AS source_policy_title, (SELECT COUNT(*) FROM runbook_steps s WHERE s.runbook_id = r.id) AS step_count, (SELECT COUNT(*) FROM runbook_steps s WHERE s.runbook_id = r.id AND s.completed_at IS NOT NULL) AS steps_completed, (SELECT COUNT(*) FROM runbook_steps s WHERE s.runbook_id = r.id AND s.skipped = 1) AS steps_skipped FROM runbooks r LEFT JOIN users gen ON gen.id = r.generated_by LEFT JOIN ir_policies p ON p.id = r.source_policy_id ${whereSql} ORDER BY CASE r.status WHEN 'active' THEN 0 WHEN 'draft' THEN 1 WHEN 'completed' THEN 2 ELSE 3 END, r.generated_at DESC`).all(…params);
+db.close();
+} catch (err) {
+logger.error(‘Failed to list runbooks’, { error: err.message });
+return res.status(500).json({ error: ‘failed to list runbooks’ });
+}
+
+const runbooks = rows.map((r) => ({
+id: r.id,
+scenarioType: r.scenario_type,
+title: r.title,
+status: r.status,
+sourcePolicyId: r.source_policy_id,
+sourcePolicyVersion: r.source_policy_version,
+sourcePolicyTitle: r.source_policy_title,
+generatedAt: r.generated_at,
+generatedBy: r.generated_by_name || r.generated_by,
+activatedAt: r.activated_at,
+finalizedAt: r.finalized_at,
+incidentId: r.incident_id,
+stepCount: r.step_count,
+stepsCompleted: r.steps_completed,
+stepsSkipped: r.steps_skipped,
+}));
+
+return res.json({ runbooks });
+});
+
+// ── GET /api/runbooks/:id — fetch one runbook with steps ────────────────────
+router.get(’/:id’, (req, res) => {
+const runbookId = req.params.id;
+if (!runbookId || typeof runbookId !== ‘string’ || runbookId.length > 64) {
+return res.status(400).json({ error: ‘invalid runbook id’ });
+}
+
+try {
+const db = getDb();
+const r = db.prepare(`SELECT r.*, gen.name AS generated_by_name, act.name AS activated_by_name, fin.name AS finalized_by_name, p.title AS source_policy_title FROM runbooks r LEFT JOIN users gen ON gen.id = r.generated_by LEFT JOIN users act ON act.id = r.activated_by LEFT JOIN users fin ON fin.id = r.finalized_by LEFT JOIN ir_policies p ON p.id = r.source_policy_id WHERE r.id = ?`).get(runbookId);
+
+```
+if (!r) {
+  db.close();
+  return res.status(404).json({ error: 'runbook not found' });
+}
+
+const stepRows = db.prepare(`
+  SELECT
+    s.*,
+    comp.name AS completed_by_name
+  FROM runbook_steps s
+  LEFT JOIN users comp ON comp.id = s.completed_by
+  WHERE s.runbook_id = ?
+  ORDER BY s.step_number ASC
+`).all(runbookId);
+db.close();
+
+const steps = stepRows.map((s) => ({
+  id: s.id,
+  stepNumber: s.step_number,
+  title: s.title,
+  instruction: s.instruction,
+  expectedOutcome: s.expected_outcome,
+  isCritical: s.is_critical === 1,
+  completedAt: s.completed_at,
+  completedBy: s.completed_by_name || s.completed_by,
+  completionNote: s.completion_note,
+  skipped: s.skipped === 1,
+  skipReason: s.skip_reason,
+}));
+
+return res.json({
+  runbook: {
+    id: r.id,
+    scenarioType: r.scenario_type,
+    title: r.title,
+    status: r.status,
+    sourcePolicyId: r.source_policy_id,
+    sourcePolicyVersion: r.source_policy_version,
+    sourcePolicyTitle: r.source_policy_title,
+    generatedAt: r.generated_at,
+    generatedBy: r.generated_by_name || r.generated_by,
+    activatedAt: r.activated_at,
+    activatedBy: r.activated_by_name || r.activated_by,
+    finalizedAt: r.finalized_at,
+    finalizedBy: r.finalized_by_name || r.finalized_by,
+    incidentId: r.incident_id,
+    notes: r.notes,
+  },
+  steps,
+});
+```
+
+} catch (err) {
+logger.error(‘Failed to fetch runbook’, { runbookId, error: err.message });
+return res.status(500).json({ error: ‘failed to fetch runbook’ });
+}
+});
+
+module.exports = router;

--- a/server/routes/runbooks.js
+++ b/server/routes/runbooks.js
@@ -15,6 +15,7 @@ const { getDb } = require('../db/init');
 const { auditLog } = require('../middleware/audit');
 const { logger } = require('../services/logger');
 const notifications = require('../services/notifications');
+const { parsePolicyToSteps } = require('../services/runbook-parser');
 
 const VALID_SCENARIO_TYPES = [
   'ransomware',
@@ -30,81 +31,8 @@ const VALID_SCENARIO_TYPES = [
   'ir_team_handoff',
 ];
 
-function parsePolicyToSteps(policyContent, scenarioType) {
-  const lines = policyContent.split(/\r?\n/);
-  const steps = [];
-  let currentStep = null;
-  let inStepsSection = false;
-
-  const numberedRe = /^\s*(\d+)[\.\)]\s+(.+)/;
-  const headerStepRe = /^#{2,6}\s+(?:Step\s+)?(\d+)[:\.]?\s+(.+)/i;
-  const stepsHeaderRe = /^#{2,6}\s+(steps?|procedures?|actions?|response|recovery)\b/i;
-  const bulletRe = /^\s*[\*\-\+]\s+(.+)/;
-
-  function pushStep(s) {
-    if (!s) return;
-    const title = (s.title || '').slice(0, 200);
-    const instruction = (s.instructionLines || []).join('\n').trim() || title;
-    if (!title && !instruction) return;
-    let expectedOutcome = null;
-    const outcomeMatch = instruction.match(/(?:^|\n)\s*(?:Expected|Outcome|Result)[:\.]?\s*(.+?)(?=\n\s*\n|$)/is);
-    if (outcomeMatch) expectedOutcome = outcomeMatch[1].trim().slice(0, 1000);
-    const isCritical = /\b(CRITICAL|MANDATORY|MUST)\b/i.test(title) || /\b(CRITICAL|MANDATORY|MUST NOT FAIL)\b/i.test(instruction.slice(0, 500));
-    steps.push({
-      title,
-      instruction: instruction.slice(0, 5000),
-      expected_outcome: expectedOutcome,
-      is_critical: isCritical ? 1 : 0,
-    });
-  }
-
-  for (const line of lines) {
-    const headerStepMatch = line.match(headerStepRe);
-    if (headerStepMatch) {
-      pushStep(currentStep);
-      currentStep = { title: headerStepMatch[2].trim(), instructionLines: [] };
-      inStepsSection = true;
-      continue;
-    }
-    const numberedMatch = line.match(numberedRe);
-    if (numberedMatch) {
-      pushStep(currentStep);
-      currentStep = { title: numberedMatch[2].trim(), instructionLines: [] };
-      inStepsSection = true;
-      continue;
-    }
-    if (stepsHeaderRe.test(line)) {
-      inStepsSection = true;
-      continue;
-    }
-    if (inStepsSection) {
-      const bulletMatch = line.match(bulletRe);
-      if (bulletMatch && !currentStep) {
-        currentStep = { title: bulletMatch[1].trim(), instructionLines: [] };
-        continue;
-      }
-      if (bulletMatch && currentStep) {
-        currentStep.instructionLines.push('* ' + bulletMatch[1].trim());
-        continue;
-      }
-      if (line.trim() && currentStep) {
-        currentStep.instructionLines.push(line);
-      }
-    }
-  }
-  pushStep(currentStep);
-
-  if (steps.length === 0) {
-    steps.push({
-      title: 'Review the source policy and add steps manually',
-      instruction: 'The runbook generator could not extract structured steps from this policy. Open the source policy in the IR Simulator policies tab, identify the recovery procedure, and add steps to this runbook in draft state before activating.',
-      expected_outcome: null,
-      is_critical: 0,
-    });
-  }
-
-  return steps;
-}
+// Parser is in services/runbook-parser.js — extracted in commit 4a so it can
+// be tested in isolation and reused by future scenario generators.
 
 router.post('/generate', (req, res) => {
   if (!['lead', 'admin'].includes(req.user.role)) {

--- a/server/routes/runbooks.js
+++ b/server/routes/runbooks.js
@@ -203,4 +203,282 @@ router.get('/:id', (req, res) => {
   }
 });
 
+router.post('/:id/activate', (req, res) => {
+  if (!['lead', 'admin'].includes(req.user.role)) {
+    return res.status(403).json({ error: 'forbidden' });
+  }
+  const runbookId = req.params.id;
+  if (!runbookId || typeof runbookId !== 'string' || runbookId.length > 64) {
+    return res.status(400).json({ error: 'invalid runbook id' });
+  }
+  const incidentId = (req.body && typeof req.body.incidentId === 'string') ? req.body.incidentId.slice(0, 128) : null;
+  const now = new Date().toISOString();
+  let runbookMeta;
+  try {
+    const db = getDb();
+    const existing = db.prepare('SELECT id, status, scenario_type, title FROM runbooks WHERE id = ?').get(runbookId);
+    if (!existing) { db.close(); return res.status(404).json({ error: 'runbook not found' }); }
+    if (existing.status !== 'draft') { db.close(); return res.status(409).json({ error: 'cannot activate runbook in ' + existing.status + ' status - only draft runbooks can be activated' }); }
+    const sets = ["status = 'active'", 'activated_at = ?', 'activated_by = ?'];
+    const params = [now, req.user.id];
+    if (incidentId !== null) { sets.push('incident_id = ?'); params.push(incidentId); }
+    params.push(runbookId);
+    db.prepare('UPDATE runbooks SET ' + sets.join(', ') + ' WHERE id = ?').run(...params);
+    runbookMeta = { scenarioType: existing.scenario_type, title: existing.title };
+    db.close();
+  } catch (err) {
+    logger.error('Failed to activate runbook', { runbookId, error: err.message });
+    return res.status(500).json({ error: 'failed to activate runbook' });
+  }
+  try {
+    const db = getDb();
+    const recipients = db.prepare("SELECT id FROM users WHERE role IN ('lead', 'admin')").all();
+    db.close();
+    for (const r of recipients) {
+      notifications.notify('runbook_activated', r.id, {
+        title: 'IR Recovery Runbook ACTIVATED',
+        body: 'Incident response is in progress. Runbook "' + runbookMeta.title + '" (' + runbookMeta.scenarioType.replace(/_/g, ' ') + ') is now active.',
+        linkTab: 'runbook',
+        linkParams: JSON.stringify({ runbookId }),
+      }).catch((notifyErr) => {
+        logger.error('Failed to deliver runbook_activated notification', { error: notifyErr.message, recipientId: r.id });
+      });
+    }
+  } catch (err) {
+    logger.error('Failed to enumerate runbook_activated recipients', { error: err.message });
+  }
+  auditLog(req.user.id, 'RUNBOOK_ACTIVATED', runbookId + ' (' + runbookMeta.scenarioType + ')' + (incidentId ? ' incident=' + incidentId : ''), req.ip);
+  return res.json({ id: runbookId, status: 'active', activatedAt: now });
+});
+
+router.post('/:id/finalize', (req, res) => {
+  if (!['lead', 'admin'].includes(req.user.role)) {
+    return res.status(403).json({ error: 'forbidden' });
+  }
+  const runbookId = req.params.id;
+  if (!runbookId || typeof runbookId !== 'string' || runbookId.length > 64) {
+    return res.status(400).json({ error: 'invalid runbook id' });
+  }
+  const finalNotes = (req.body && typeof req.body.notes === 'string') ? req.body.notes.slice(0, 5000) : null;
+  const now = new Date().toISOString();
+  let runbookMeta;
+  try {
+    const db = getDb();
+    const existing = db.prepare('SELECT id, status, scenario_type, title FROM runbooks WHERE id = ?').get(runbookId);
+    if (!existing) { db.close(); return res.status(404).json({ error: 'runbook not found' }); }
+    if (existing.status !== 'active') { db.close(); return res.status(409).json({ error: 'cannot finalize runbook in ' + existing.status + ' status - only active runbooks can be finalized' }); }
+    const sets = ["status = 'completed'", 'finalized_at = ?', 'finalized_by = ?'];
+    const params = [now, req.user.id];
+    if (finalNotes !== null) { sets.push('notes = ?'); params.push(finalNotes); }
+    params.push(runbookId);
+    db.prepare('UPDATE runbooks SET ' + sets.join(', ') + ' WHERE id = ?').run(...params);
+    runbookMeta = { scenarioType: existing.scenario_type, title: existing.title };
+    db.close();
+  } catch (err) {
+    logger.error('Failed to finalize runbook', { runbookId, error: err.message });
+    return res.status(500).json({ error: 'failed to finalize runbook' });
+  }
+  try {
+    const db = getDb();
+    const recipients = db.prepare("SELECT id FROM users WHERE role IN ('lead', 'admin')").all();
+    db.close();
+    for (const r of recipients) {
+      notifications.notify('runbook_finalized', r.id, {
+        title: 'IR Recovery Runbook finalized',
+        body: 'Incident response complete. Runbook "' + runbookMeta.title + '" has been finalized.',
+        linkTab: 'runbook',
+        linkParams: JSON.stringify({ runbookId }),
+      }).catch((notifyErr) => {
+        logger.error('Failed to deliver runbook_finalized notification', { error: notifyErr.message, recipientId: r.id });
+      });
+    }
+  } catch (err) {
+    logger.error('Failed to enumerate runbook_finalized recipients', { error: err.message });
+  }
+  auditLog(req.user.id, 'RUNBOOK_FINALIZED', runbookId + ' (' + runbookMeta.scenarioType + ')', req.ip);
+  return res.json({ id: runbookId, status: 'completed', finalizedAt: now });
+});
+
+
+router.post('/:id/cancel', (req, res) => {
+  if (!['lead', 'admin'].includes(req.user.role)) {
+    return res.status(403).json({ error: 'forbidden' });
+  }
+  const runbookId = req.params.id;
+  if (!runbookId || typeof runbookId !== 'string' || runbookId.length > 64) {
+    return res.status(400).json({ error: 'invalid runbook id' });
+  }
+  const reason = (req.body && typeof req.body.reason === 'string') ? req.body.reason.slice(0, 2000) : null;
+  const now = new Date().toISOString();
+  try {
+    const db = getDb();
+    const existing = db.prepare('SELECT id, status FROM runbooks WHERE id = ?').get(runbookId);
+    if (!existing) { db.close(); return res.status(404).json({ error: 'runbook not found' }); }
+    if (!['draft', 'active'].includes(existing.status)) { db.close(); return res.status(409).json({ error: 'cannot cancel runbook in ' + existing.status + ' status' }); }
+    const cancellationNote = reason ? '[CANCELLED ' + now + '] ' + reason : '[CANCELLED ' + now + ']';
+    db.prepare("UPDATE runbooks SET status = 'cancelled', finalized_at = ?, finalized_by = ?, notes = COALESCE(notes || char(10) || char(10), '') || ? WHERE id = ?").run(now, req.user.id, cancellationNote, runbookId);
+    db.close();
+  } catch (err) {
+    logger.error('Failed to cancel runbook', { runbookId, error: err.message });
+    return res.status(500).json({ error: 'failed to cancel runbook' });
+  }
+  auditLog(req.user.id, 'RUNBOOK_CANCELLED', runbookId + (reason ? ' reason=' + reason.slice(0, 200) : ''), req.ip);
+  return res.json({ id: runbookId, status: 'cancelled', cancelledAt: now });
+});
+
+router.post('/:id/steps/:stepId/complete', (req, res) => {
+  const runbookId = req.params.id;
+  const stepId = req.params.stepId;
+  if (!runbookId || !stepId || typeof runbookId !== 'string' || typeof stepId !== 'string') {
+    return res.status(400).json({ error: 'invalid runbook or step id' });
+  }
+  const note = (req.body && typeof req.body.note === 'string') ? req.body.note.slice(0, 2000) : null;
+  const now = new Date().toISOString();
+  let stepMeta;
+  try {
+    const db = getDb();
+    const runbook = db.prepare('SELECT id, status, scenario_type, title FROM runbooks WHERE id = ?').get(runbookId);
+    if (!runbook) { db.close(); return res.status(404).json({ error: 'runbook not found' }); }
+    if (runbook.status !== 'active') { db.close(); return res.status(409).json({ error: 'cannot complete steps in ' + runbook.status + ' runbook - only active runbooks accept step completion' }); }
+    const step = db.prepare('SELECT id, runbook_id, step_number, title, completed_at, skipped FROM runbook_steps WHERE id = ? AND runbook_id = ?').get(stepId, runbookId);
+    if (!step) { db.close(); return res.status(404).json({ error: 'step not found in this runbook' }); }
+    if (step.completed_at) { db.close(); return res.status(409).json({ error: 'step already completed' }); }
+    if (step.skipped === 1) { db.close(); return res.status(409).json({ error: 'step was skipped - cannot complete' }); }
+    db.prepare('UPDATE runbook_steps SET completed_at = ?, completed_by = ?, completion_note = ? WHERE id = ?').run(now, req.user.id, note, stepId);
+    stepMeta = { stepNumber: step.step_number, stepTitle: step.title, runbookTitle: runbook.title };
+    db.close();
+  } catch (err) {
+    logger.error('Failed to complete runbook step', { runbookId, stepId, error: err.message });
+    return res.status(500).json({ error: 'failed to complete step' });
+  }
+  try {
+    const db = getDb();
+    const recipients = db.prepare("SELECT id FROM users WHERE role IN ('lead', 'admin')").all();
+    db.close();
+    for (const r of recipients) {
+      notifications.notify('runbook_step_completed', r.id, {
+        title: 'Runbook step ' + stepMeta.stepNumber + ' complete',
+        body: '"' + stepMeta.stepTitle + '" marked complete in runbook "' + stepMeta.runbookTitle + '".',
+        linkTab: 'runbook',
+        linkParams: JSON.stringify({ runbookId }),
+      }).catch(() => {});
+    }
+  } catch (err) {
+    logger.error('Failed to enumerate runbook_step_completed recipients', { error: err.message });
+  }
+  auditLog(req.user.id, 'RUNBOOK_STEP_COMPLETED', runbookId + ' step ' + stepMeta.stepNumber + ': ' + stepMeta.stepTitle.slice(0, 60), req.ip);
+  return res.json({ id: stepId, runbookId, completedAt: now });
+});
+
+router.post('/:id/steps/:stepId/skip', (req, res) => {
+  if (!['lead', 'admin'].includes(req.user.role)) {
+    return res.status(403).json({ error: 'forbidden' });
+  }
+  const runbookId = req.params.id;
+  const stepId = req.params.stepId;
+  if (!runbookId || !stepId || typeof runbookId !== 'string' || typeof stepId !== 'string') {
+    return res.status(400).json({ error: 'invalid runbook or step id' });
+  }
+  const reason = (req.body && typeof req.body.reason === 'string') ? req.body.reason.slice(0, 2000) : null;
+  let stepMeta;
+  try {
+    const db = getDb();
+    const runbook = db.prepare('SELECT id, status FROM runbooks WHERE id = ?').get(runbookId);
+    if (!runbook) { db.close(); return res.status(404).json({ error: 'runbook not found' }); }
+    if (runbook.status !== 'active') { db.close(); return res.status(409).json({ error: 'cannot skip steps in ' + runbook.status + ' runbook - only active runbooks accept step skips' }); }
+    const step = db.prepare('SELECT id, step_number, title, is_critical, completed_at, skipped FROM runbook_steps WHERE id = ? AND runbook_id = ?').get(stepId, runbookId);
+    if (!step) { db.close(); return res.status(404).json({ error: 'step not found in this runbook' }); }
+    if (step.completed_at) { db.close(); return res.status(409).json({ error: 'step already completed - cannot skip' }); }
+    if (step.skipped === 1) { db.close(); return res.status(409).json({ error: 'step already skipped' }); }
+    if (step.is_critical === 1 && !reason) { db.close(); return res.status(400).json({ error: 'critical steps require a skip reason' }); }
+    db.prepare('UPDATE runbook_steps SET skipped = 1, skip_reason = ? WHERE id = ?').run(reason, stepId);
+    stepMeta = { stepNumber: step.step_number, stepTitle: step.title, isCritical: step.is_critical === 1 };
+    db.close();
+  } catch (err) {
+    logger.error('Failed to skip runbook step', { runbookId, stepId, error: err.message });
+    return res.status(500).json({ error: 'failed to skip step' });
+  }
+  auditLog(req.user.id, 'RUNBOOK_STEP_SKIPPED', runbookId + ' step ' + stepMeta.stepNumber + ' (' + (stepMeta.isCritical ? 'CRITICAL' : 'non-critical') + ')' + (reason ? ' reason=' + reason.slice(0, 200) : ''), req.ip);
+  return res.json({ id: stepId, runbookId, skipped: true });
+});
+
+router.get('/scenarios/:type/policies', (req, res) => {
+  const scenarioType = req.params.type;
+  if (!VALID_SCENARIO_TYPES.includes(scenarioType)) {
+    return res.status(400).json({ error: 'scenarioType must be one of: ' + VALID_SCENARIO_TYPES.join(', ') });
+  }
+  try {
+    const db = getDb();
+    const tagged = db.prepare('SELECT p.id, p.title, p.policy_type, p.version, p.uploaded_at, rsp.is_default FROM runbook_scenario_policies rsp INNER JOIN ir_policies p ON p.id = rsp.policy_id WHERE rsp.scenario_type = ? AND p.deleted_at IS NULL ORDER BY rsp.is_default DESC, p.uploaded_at DESC').all(scenarioType);
+    const allPolicies = db.prepare("SELECT id, title, policy_type, version, uploaded_at FROM ir_policies WHERE deleted_at IS NULL AND id NOT IN (SELECT policy_id FROM runbook_scenario_policies WHERE scenario_type = ?) ORDER BY uploaded_at DESC").all(scenarioType);
+    db.close();
+    return res.json({
+      scenarioType,
+      tagged: tagged.map((p) => ({ id: p.id, title: p.title, policyType: p.policy_type, version: p.version, uploadedAt: p.uploaded_at, isDefault: p.is_default === 1 })),
+      untagged: allPolicies.map((p) => ({ id: p.id, title: p.title, policyType: p.policy_type, version: p.version, uploadedAt: p.uploaded_at })),
+    });
+  } catch (err) {
+    logger.error('Failed to list scenario policies', { scenarioType, error: err.message });
+    return res.status(500).json({ error: 'failed to list scenario policies' });
+  }
+});
+
+router.post('/scenarios/:type/policies', (req, res) => {
+  if (!['lead', 'admin'].includes(req.user.role)) {
+    return res.status(403).json({ error: 'forbidden' });
+  }
+  const scenarioType = req.params.type;
+  if (!VALID_SCENARIO_TYPES.includes(scenarioType)) {
+    return res.status(400).json({ error: 'scenarioType must be one of: ' + VALID_SCENARIO_TYPES.join(', ') });
+  }
+  const { policyId, isDefault } = req.body || {};
+  if (!policyId || typeof policyId !== 'string') {
+    return res.status(400).json({ error: 'policyId required' });
+  }
+  const setDefault = isDefault === true || isDefault === 1;
+  try {
+    const db = getDb();
+    const policy = db.prepare('SELECT id FROM ir_policies WHERE id = ? AND deleted_at IS NULL').get(policyId);
+    if (!policy) { db.close(); return res.status(404).json({ error: 'policy not found or deleted' }); }
+    const txn = db.transaction(() => {
+      if (setDefault) {
+        db.prepare('UPDATE runbook_scenario_policies SET is_default = 0 WHERE scenario_type = ?').run(scenarioType);
+      }
+      db.prepare('INSERT OR REPLACE INTO runbook_scenario_policies (scenario_type, policy_id, is_default, added_by) VALUES (?, ?, ?, ?)').run(scenarioType, policyId, setDefault ? 1 : 0, req.user.id);
+    });
+    txn();
+    db.close();
+  } catch (err) {
+    logger.error('Failed to tag scenario policy', { scenarioType, policyId, error: err.message });
+    return res.status(500).json({ error: 'failed to tag policy' });
+  }
+  auditLog(req.user.id, 'RUNBOOK_SCENARIO_POLICY_TAGGED', scenarioType + ' policy=' + policyId + (setDefault ? ' (default)' : ''), req.ip);
+  return res.status(201).json({ scenarioType, policyId, isDefault: setDefault });
+});
+
+router.delete('/scenarios/:type/policies/:policyId', (req, res) => {
+  if (!['lead', 'admin'].includes(req.user.role)) {
+    return res.status(403).json({ error: 'forbidden' });
+  }
+  const scenarioType = req.params.type;
+  const policyId = req.params.policyId;
+  if (!VALID_SCENARIO_TYPES.includes(scenarioType)) {
+    return res.status(400).json({ error: 'scenarioType must be one of: ' + VALID_SCENARIO_TYPES.join(', ') });
+  }
+  try {
+    const db = getDb();
+    const result = db.prepare('DELETE FROM runbook_scenario_policies WHERE scenario_type = ? AND policy_id = ?').run(scenarioType, policyId);
+    db.close();
+    if (result.changes === 0) {
+      return res.status(404).json({ error: 'policy not tagged for this scenario' });
+    }
+  } catch (err) {
+    logger.error('Failed to untag scenario policy', { scenarioType, policyId, error: err.message });
+    return res.status(500).json({ error: 'failed to untag policy' });
+  }
+  auditLog(req.user.id, 'RUNBOOK_SCENARIO_POLICY_UNTAGGED', scenarioType + ' policy=' + policyId, req.ip);
+  return res.json({ ok: true });
+});
+
 module.exports = router;
+

--- a/server/routes/runbooks.js
+++ b/server/routes/runbooks.js
@@ -3,317 +3,200 @@
 //
 // Org-policy-driven runbooks. Leads pick a scenario type and an uploaded IR
 // policy; the parser extracts ordered steps from the policy and creates a
-// runbook in ‘draft’ status. The lead reviews and edits before activating.
+// runbook in 'draft' status. The lead reviews and edits before activating.
 // During an active incident, analysts/leads tick off steps with optional
 // completion notes. When the incident is over, the runbook is finalized
 // and becomes part of the immutable audit trail.
-//
-// POST /api/runbooks/generate                  — generate from policy (lead/admin)
-// GET  /api/runbooks                            — list runbooks with filters
-// GET  /api/runbooks/:id                        — fetch runbook + steps
-// POST /api/runbooks/:id/activate               — draft → active (lead/admin)
-// POST /api/runbooks/:id/finalize               — active → completed (lead/admin)
-// POST /api/runbooks/:id/cancel                 — any → cancelled (lead/admin)
-// POST /api/runbooks/:id/steps/:stepId/complete — mark step done (any role)
-// POST /api/runbooks/:id/steps/:stepId/skip     — mark step skipped (lead/admin)
-// GET  /api/runbooks/scenarios/:type/policies   — list policies tagged for scenario
-//
-// Activate, finalize, cancel, complete-step, skip-step, and the scenario-policies
-// endpoint live in commits 4 and 5 of this PR. This commit ships generate,
-// list, and fetch.
 // ═══════════════════════════════════════════════════════════════════════════════
 
-const router = require(‘express’).Router();
-const crypto = require(‘crypto’);
-const { getDb } = require(’../db/init’);
-const { auditLog } = require(’../middleware/audit’);
-const { logger } = require(’../services/logger’);
-const notifications = require(’../services/notifications’);
+const router = require('express').Router();
+const crypto = require('crypto');
+const { getDb } = require('../db/init');
+const { auditLog } = require('../middleware/audit');
+const { logger } = require('../services/logger');
+const notifications = require('../services/notifications');
 
-// Valid scenario types. Match the OODA simulator’s vocabulary where it
-// overlaps, with additional types for incidents the OODA simulator doesn’t
-// model (server crash, backup restoration, etc).
 const VALID_SCENARIO_TYPES = [
-‘ransomware’,
-‘data_exfiltration’,
-‘insider_threat’,
-‘credential_compromise’,
-‘ddos’,
-‘supply_chain’,
-‘cloud_account_compromise’,
-‘database_corruption’,
-‘server_crash’,
-‘backup_restoration’,
-‘ir_team_handoff’,
+  'ransomware',
+  'data_exfiltration',
+  'insider_threat',
+  'credential_compromise',
+  'ddos',
+  'supply_chain',
+  'cloud_account_compromise',
+  'database_corruption',
+  'server_crash',
+  'backup_restoration',
+  'ir_team_handoff',
 ];
 
-// ── Inline policy → steps parser ─────────────────────────────────────────────
-//
-// Will be extracted to server/services/runbook-parser.js in commit 4 once
-// the route is shipping. Inlined here so this commit is a self-contained
-// vertical slice.
 function parsePolicyToSteps(policyContent, scenarioType) {
-const lines = policyContent.split(/\r?\n/);
-const steps = [];
-let currentStep = null;
-let inStepsSection = false;
+  const lines = policyContent.split(/\r?\n/);
+  const steps = [];
+  let currentStep = null;
+  let inStepsSection = false;
 
-const numberedRe = /^\s*(\d+)[.)]\s+(.+)/;
-const headerStepRe = /^#{2,6}\s+(?:Step\s+)?(\d+)[:.]?\s+(.+)/i;
-const stepsHeaderRe = /^#{2,6}\s+(steps?|procedures?|actions?|response|recovery)\b/i;
-const bulletRe = /^\s*[*-+]\s+(.+)/;
+  const numberedRe = /^\s*(\d+)[\.\)]\s+(.+)/;
+  const headerStepRe = /^#{2,6}\s+(?:Step\s+)?(\d+)[:\.]?\s+(.+)/i;
+  const stepsHeaderRe = /^#{2,6}\s+(steps?|procedures?|actions?|response|recovery)\b/i;
+  const bulletRe = /^\s*[\*\-\+]\s+(.+)/;
 
-function pushStep(s) {
-if (!s) return;
-const title = (s.title || ‘’).slice(0, 200);
-const instruction = (s.instructionLines || []).join(’\n’).trim() || title;
-if (!title && !instruction) return;
-let expectedOutcome = null;
-const outcomeMatch = instruction.match(/(?:^|\n)\s*(?:Expected|Outcome|Result)[:.]?\s*(.+?)(?=\n\s*\n|$)/is);
-if (outcomeMatch) expectedOutcome = outcomeMatch[1].trim().slice(0, 1000);
-const isCritical = /\b(CRITICAL|MANDATORY|MUST)\b/i.test(title) || /\b(CRITICAL|MANDATORY|MUST NOT FAIL)\b/i.test(instruction.slice(0, 500));
-steps.push({
-title,
-instruction: instruction.slice(0, 5000),
-expected_outcome: expectedOutcome,
-is_critical: isCritical ? 1 : 0,
-});
+  function pushStep(s) {
+    if (!s) return;
+    const title = (s.title || '').slice(0, 200);
+    const instruction = (s.instructionLines || []).join('\n').trim() || title;
+    if (!title && !instruction) return;
+    let expectedOutcome = null;
+    const outcomeMatch = instruction.match(/(?:^|\n)\s*(?:Expected|Outcome|Result)[:\.]?\s*(.+?)(?=\n\s*\n|$)/is);
+    if (outcomeMatch) expectedOutcome = outcomeMatch[1].trim().slice(0, 1000);
+    const isCritical = /\b(CRITICAL|MANDATORY|MUST)\b/i.test(title) || /\b(CRITICAL|MANDATORY|MUST NOT FAIL)\b/i.test(instruction.slice(0, 500));
+    steps.push({
+      title,
+      instruction: instruction.slice(0, 5000),
+      expected_outcome: expectedOutcome,
+      is_critical: isCritical ? 1 : 0,
+    });
+  }
+
+  for (const line of lines) {
+    const headerStepMatch = line.match(headerStepRe);
+    if (headerStepMatch) {
+      pushStep(currentStep);
+      currentStep = { title: headerStepMatch[2].trim(), instructionLines: [] };
+      inStepsSection = true;
+      continue;
+    }
+    const numberedMatch = line.match(numberedRe);
+    if (numberedMatch) {
+      pushStep(currentStep);
+      currentStep = { title: numberedMatch[2].trim(), instructionLines: [] };
+      inStepsSection = true;
+      continue;
+    }
+    if (stepsHeaderRe.test(line)) {
+      inStepsSection = true;
+      continue;
+    }
+    if (inStepsSection) {
+      const bulletMatch = line.match(bulletRe);
+      if (bulletMatch && !currentStep) {
+        currentStep = { title: bulletMatch[1].trim(), instructionLines: [] };
+        continue;
+      }
+      if (bulletMatch && currentStep) {
+        currentStep.instructionLines.push('* ' + bulletMatch[1].trim());
+        continue;
+      }
+      if (line.trim() && currentStep) {
+        currentStep.instructionLines.push(line);
+      }
+    }
+  }
+  pushStep(currentStep);
+
+  if (steps.length === 0) {
+    steps.push({
+      title: 'Review the source policy and add steps manually',
+      instruction: 'The runbook generator could not extract structured steps from this policy. Open the source policy in the IR Simulator policies tab, identify the recovery procedure, and add steps to this runbook in draft state before activating.',
+      expected_outcome: null,
+      is_critical: 0,
+    });
+  }
+
+  return steps;
 }
 
-for (const line of lines) {
-const headerStepMatch = line.match(headerStepRe);
-if (headerStepMatch) {
-pushStep(currentStep);
-currentStep = { title: headerStepMatch[2].trim(), instructionLines: [] };
-inStepsSection = true;
-continue;
-}
-const numberedMatch = line.match(numberedRe);
-if (numberedMatch) {
-pushStep(currentStep);
-currentStep = { title: numberedMatch[2].trim(), instructionLines: [] };
-inStepsSection = true;
-continue;
-}
-if (stepsHeaderRe.test(line)) {
-inStepsSection = true;
-continue;
-}
-if (inStepsSection) {
-const bulletMatch = line.match(bulletRe);
-if (bulletMatch && !currentStep) {
-currentStep = { title: bulletMatch[1].trim(), instructionLines: [] };
-continue;
-}
-if (bulletMatch && currentStep) {
-currentStep.instructionLines.push(’• ’ + bulletMatch[1].trim());
-continue;
-}
-if (line.trim() && currentStep) {
-currentStep.instructionLines.push(line);
-}
-}
-}
-pushStep(currentStep);
+router.post('/generate', (req, res) => {
+  if (!['lead', 'admin'].includes(req.user.role)) {
+    return res.status(403).json({ error: 'forbidden' });
+  }
 
-if (steps.length === 0) {
-steps.push({
-title: ‘Review the source policy and add steps manually’,
-instruction: ‘The runbook generator could not extract structured steps from this policy. Open the source policy in the IR Simulator policies tab, identify the recovery procedure, and add steps to this runbook in draft state before activating.’,
-expected_outcome: null,
-is_critical: 0,
-});
-}
+  const { scenarioType, policyId, title, incidentId } = req.body || {};
 
-return steps;
-}
+  if (!VALID_SCENARIO_TYPES.includes(scenarioType)) {
+    return res.status(400).json({ error: 'scenarioType must be one of: ' + VALID_SCENARIO_TYPES.join(', ') });
+  }
+  if (!policyId || typeof policyId !== 'string') {
+    return res.status(400).json({ error: 'policyId required' });
+  }
 
-// ── POST /api/runbooks/generate — generate a runbook from a policy ──────────
-router.post(’/generate’, (req, res) => {
-if (![‘lead’, ‘admin’].includes(req.user.role)) {
-return res.status(403).json({ error: ‘forbidden’ });
-}
+  let runbookId;
+  let policy;
+  try {
+    const db = getDb();
+    policy = db.prepare('SELECT id, title, policy_type, content, version FROM ir_policies WHERE id = ? AND deleted_at IS NULL').get(policyId);
+    if (!policy) {
+      db.close();
+      return res.status(404).json({ error: 'policy not found or deleted' });
+    }
+    const steps = parsePolicyToSteps(policy.content, scenarioType);
+    runbookId = crypto.randomBytes(16).toString('hex');
+    const safeTitle = (title && typeof title === 'string') ? title.slice(0, 256) : (scenarioType.replace(/_/g, ' ') + ' runbook from "' + policy.title + '"');
+    const safeIncidentId = (incidentId && typeof incidentId === 'string') ? incidentId.slice(0, 128) : null;
+    const now = new Date().toISOString();
+    const insertRunbook = db.prepare("INSERT INTO runbooks (id, scenario_type, title, source_policy_id, source_policy_version, status, generated_by, generated_at, incident_id) VALUES (?, ?, ?, ?, ?, 'draft', ?, ?, ?)");
+    const insertStep = db.prepare('INSERT INTO runbook_steps (id, runbook_id, step_number, title, instruction, expected_outcome, is_critical) VALUES (?, ?, ?, ?, ?, ?, ?)');
+    const txn = db.transaction(() => {
+      insertRunbook.run(runbookId, scenarioType, safeTitle, policy.id, policy.version, req.user.id, now, safeIncidentId);
+      steps.forEach((s, idx) => {
+        insertStep.run(crypto.randomBytes(16).toString('hex'), runbookId, idx + 1, s.title, s.instruction, s.expected_outcome, s.is_critical);
+      });
+    });
+    txn();
+    db.close();
+  } catch (err) {
+    logger.error('Failed to generate runbook', { error: err.message, scenarioType, policyId });
+    return res.status(500).json({ error: 'failed to generate runbook' });
+  }
 
-const { scenarioType, policyId, title, incidentId } = req.body || {};
+  try {
+    const db = getDb();
+    const recipients = db.prepare("SELECT id FROM users WHERE role IN ('lead', 'admin')").all();
+    db.close();
+    for (const r of recipients) {
+      notifications.notify('runbook_generated', r.id, {
+        title: 'IR Recovery Runbook generated (draft)',
+        body: 'A new ' + scenarioType.replace(/_/g, ' ') + ' runbook is in draft status from policy "' + policy.title + '". Review and activate when ready.',
+        linkTab: 'runbook',
+        linkParams: JSON.stringify({ runbookId }),
+      }).catch((notifyErr) => {
+        logger.error('Failed to deliver runbook_generated notification', { error: notifyErr.message, recipientId: r.id });
+      });
+    }
+  } catch (err) {
+    logger.error('Failed to enumerate runbook_generated recipients', { error: err.message });
+  }
 
-if (!VALID_SCENARIO_TYPES.includes(scenarioType)) {
-return res.status(400).json({ error: `scenarioType must be one of: ${VALID_SCENARIO_TYPES.join(', ')}` });
-}
-if (!policyId || typeof policyId !== ‘string’) {
-return res.status(400).json({ error: ‘policyId required’ });
-}
+  auditLog(req.user.id, 'RUNBOOK_GENERATED', scenarioType + ' from policy ' + policyId + ' (v' + policy.version + ')', req.ip);
 
-let runbookId;
-let policy;
-try {
-const db = getDb();
-
-```
-policy = db.prepare(`
-  SELECT id, title, policy_type, content, version
-  FROM ir_policies
-  WHERE id = ? AND deleted_at IS NULL
-`).get(policyId);
-
-if (!policy) {
-  db.close();
-  return res.status(404).json({ error: 'policy not found or deleted' });
-}
-
-const steps = parsePolicyToSteps(policy.content, scenarioType);
-
-runbookId = crypto.randomBytes(16).toString('hex');
-const safeTitle = (title && typeof title === 'string')
-  ? title.slice(0, 256)
-  : `${scenarioType.replace(/_/g, ' ')} runbook from "${policy.title}"`;
-const safeIncidentId = (incidentId && typeof incidentId === 'string') ? incidentId.slice(0, 128) : null;
-const now = new Date().toISOString();
-
-const insertRunbook = db.prepare(`
-  INSERT INTO runbooks
-    (id, scenario_type, title, source_policy_id, source_policy_version, status, generated_by, generated_at, incident_id)
-  VALUES (?, ?, ?, ?, ?, 'draft', ?, ?, ?)
-`);
-const insertStep = db.prepare(`
-  INSERT INTO runbook_steps
-    (id, runbook_id, step_number, title, instruction, expected_outcome, is_critical)
-  VALUES (?, ?, ?, ?, ?, ?, ?)
-`);
-
-const txn = db.transaction(() => {
-  insertRunbook.run(runbookId, scenarioType, safeTitle, policy.id, policy.version, req.user.id, now, safeIncidentId);
-  steps.forEach((s, idx) => {
-    insertStep.run(crypto.randomBytes(16).toString('hex'), runbookId, idx + 1, s.title, s.instruction, s.expected_outcome, s.is_critical);
+  return res.status(201).json({
+    id: runbookId,
+    scenarioType,
+    sourcePolicyId: policy.id,
+    sourcePolicyVersion: policy.version,
+    status: 'draft',
   });
 });
-txn();
+router.get('/', (req, res) => {
+  const status = ['draft', 'active', 'completed', 'cancelled', 'all'].includes(req.query.status) ? req.query.status : 'all';
+  const scenario = VALID_SCENARIO_TYPES.includes(req.query.scenario) ? req.query.scenario : null;
+  const where = [];
+  const params = [];
+  if (status !== 'all') { where.push('r.status = ?'); params.push(status); }
+  if (scenario) { where.push('r.scenario_type = ?'); params.push(scenario); }
+  const whereSql = where.length > 0 ? ' WHERE ' + where.join(' AND ') : '';
 
-db.close();
-```
+  let rows;
+  try {
+    const db = getDb();
+    rows = db.prepare("SELECT r.id, r.scenario_type, r.title, r.status, r.source_policy_id, r.source_policy_version, r.generated_at, r.generated_by, r.activated_at, r.finalized_at, r.incident_id, gen.name AS generated_by_name, p.title AS source_policy_title, (SELECT COUNT(*) FROM runbook_steps s WHERE s.runbook_id = r.id) AS step_count, (SELECT COUNT(*) FROM runbook_steps s WHERE s.runbook_id = r.id AND s.completed_at IS NOT NULL) AS steps_completed, (SELECT COUNT(*) FROM runbook_steps s WHERE s.runbook_id = r.id AND s.skipped = 1) AS steps_skipped FROM runbooks r LEFT JOIN users gen ON gen.id = r.generated_by LEFT JOIN ir_policies p ON p.id = r.source_policy_id" + whereSql + " ORDER BY CASE r.status WHEN 'active' THEN 0 WHEN 'draft' THEN 1 WHEN 'completed' THEN 2 ELSE 3 END, r.generated_at DESC").all(...params);
+    db.close();
+  } catch (err) {
+    logger.error('Failed to list runbooks', { error: err.message });
+    return res.status(500).json({ error: 'failed to list runbooks' });
+  }
 
-} catch (err) {
-logger.error(‘Failed to generate runbook’, { error: err.message, scenarioType, policyId });
-return res.status(500).json({ error: ‘failed to generate runbook’ });
-}
-
-try {
-const db = getDb();
-const recipients = db.prepare(“SELECT id FROM users WHERE role IN (‘lead’, ‘admin’)”).all();
-db.close();
-for (const r of recipients) {
-notifications.notify(‘runbook_generated’, r.id, {
-title: ‘IR Recovery Runbook generated (draft)’,
-body: `A new ${scenarioType.replace(/_/g, ' ')} runbook is in draft status from policy "${policy.title}". Review and activate when ready.`,
-linkTab: ‘runbook’,
-linkParams: JSON.stringify({ runbookId }),
-}).catch((notifyErr) => {
-logger.error(‘Failed to deliver runbook_generated notification’, {
-error: notifyErr.message,
-recipientId: r.id,
-});
-});
-}
-} catch (err) {
-logger.error(‘Failed to enumerate runbook_generated recipients’, { error: err.message });
-}
-
-auditLog(req.user.id, ‘RUNBOOK_GENERATED’, `${scenarioType} from policy ${policyId} (v${policy.version})`, req.ip);
-
-return res.status(201).json({
-id: runbookId,
-scenarioType,
-sourcePolicyId: policy.id,
-sourcePolicyVersion: policy.version,
-status: ‘draft’,
-});
-});
-
-// ── GET /api/runbooks — list with filters ───────────────────────────────────
-router.get(’/’, (req, res) => {
-const status = [‘draft’, ‘active’, ‘completed’, ‘cancelled’, ‘all’].includes(req.query.status) ? req.query.status : ‘all’;
-const scenario = VALID_SCENARIO_TYPES.includes(req.query.scenario) ? req.query.scenario : null;
-
-const where = [];
-const params = [];
-if (status !== ‘all’) { where.push(‘r.status = ?’); params.push(status); }
-if (scenario) { where.push(‘r.scenario_type = ?’); params.push(scenario); }
-const whereSql = where.length > 0 ? ’ WHERE ’ + where.join(’ AND ’) : ‘’;
-
-let rows;
-try {
-const db = getDb();
-rows = db.prepare(`SELECT r.id, r.scenario_type, r.title, r.status, r.source_policy_id, r.source_policy_version, r.generated_at, r.generated_by, r.activated_at, r.finalized_at, r.incident_id, gen.name AS generated_by_name, p.title AS source_policy_title, (SELECT COUNT(*) FROM runbook_steps s WHERE s.runbook_id = r.id) AS step_count, (SELECT COUNT(*) FROM runbook_steps s WHERE s.runbook_id = r.id AND s.completed_at IS NOT NULL) AS steps_completed, (SELECT COUNT(*) FROM runbook_steps s WHERE s.runbook_id = r.id AND s.skipped = 1) AS steps_skipped FROM runbooks r LEFT JOIN users gen ON gen.id = r.generated_by LEFT JOIN ir_policies p ON p.id = r.source_policy_id ${whereSql} ORDER BY CASE r.status WHEN 'active' THEN 0 WHEN 'draft' THEN 1 WHEN 'completed' THEN 2 ELSE 3 END, r.generated_at DESC`).all(…params);
-db.close();
-} catch (err) {
-logger.error(‘Failed to list runbooks’, { error: err.message });
-return res.status(500).json({ error: ‘failed to list runbooks’ });
-}
-
-const runbooks = rows.map((r) => ({
-id: r.id,
-scenarioType: r.scenario_type,
-title: r.title,
-status: r.status,
-sourcePolicyId: r.source_policy_id,
-sourcePolicyVersion: r.source_policy_version,
-sourcePolicyTitle: r.source_policy_title,
-generatedAt: r.generated_at,
-generatedBy: r.generated_by_name || r.generated_by,
-activatedAt: r.activated_at,
-finalizedAt: r.finalized_at,
-incidentId: r.incident_id,
-stepCount: r.step_count,
-stepsCompleted: r.steps_completed,
-stepsSkipped: r.steps_skipped,
-}));
-
-return res.json({ runbooks });
-});
-
-// ── GET /api/runbooks/:id — fetch one runbook with steps ────────────────────
-router.get(’/:id’, (req, res) => {
-const runbookId = req.params.id;
-if (!runbookId || typeof runbookId !== ‘string’ || runbookId.length > 64) {
-return res.status(400).json({ error: ‘invalid runbook id’ });
-}
-
-try {
-const db = getDb();
-const r = db.prepare(`SELECT r.*, gen.name AS generated_by_name, act.name AS activated_by_name, fin.name AS finalized_by_name, p.title AS source_policy_title FROM runbooks r LEFT JOIN users gen ON gen.id = r.generated_by LEFT JOIN users act ON act.id = r.activated_by LEFT JOIN users fin ON fin.id = r.finalized_by LEFT JOIN ir_policies p ON p.id = r.source_policy_id WHERE r.id = ?`).get(runbookId);
-
-```
-if (!r) {
-  db.close();
-  return res.status(404).json({ error: 'runbook not found' });
-}
-
-const stepRows = db.prepare(`
-  SELECT
-    s.*,
-    comp.name AS completed_by_name
-  FROM runbook_steps s
-  LEFT JOIN users comp ON comp.id = s.completed_by
-  WHERE s.runbook_id = ?
-  ORDER BY s.step_number ASC
-`).all(runbookId);
-db.close();
-
-const steps = stepRows.map((s) => ({
-  id: s.id,
-  stepNumber: s.step_number,
-  title: s.title,
-  instruction: s.instruction,
-  expectedOutcome: s.expected_outcome,
-  isCritical: s.is_critical === 1,
-  completedAt: s.completed_at,
-  completedBy: s.completed_by_name || s.completed_by,
-  completionNote: s.completion_note,
-  skipped: s.skipped === 1,
-  skipReason: s.skip_reason,
-}));
-
-return res.json({
-  runbook: {
+  const runbooks = rows.map((r) => ({
     id: r.id,
     scenarioType: r.scenario_type,
     title: r.title,
@@ -324,20 +207,72 @@ return res.json({
     generatedAt: r.generated_at,
     generatedBy: r.generated_by_name || r.generated_by,
     activatedAt: r.activated_at,
-    activatedBy: r.activated_by_name || r.activated_by,
     finalizedAt: r.finalized_at,
-    finalizedBy: r.finalized_by_name || r.finalized_by,
     incidentId: r.incident_id,
-    notes: r.notes,
-  },
-  steps,
-});
-```
+    stepCount: r.step_count,
+    stepsCompleted: r.steps_completed,
+    stepsSkipped: r.steps_skipped,
+  }));
 
-} catch (err) {
-logger.error(‘Failed to fetch runbook’, { runbookId, error: err.message });
-return res.status(500).json({ error: ‘failed to fetch runbook’ });
-}
+  return res.json({ runbooks });
+});
+
+router.get('/:id', (req, res) => {
+  const runbookId = req.params.id;
+  if (!runbookId || typeof runbookId !== 'string' || runbookId.length > 64) {
+    return res.status(400).json({ error: 'invalid runbook id' });
+  }
+
+  try {
+    const db = getDb();
+    const r = db.prepare('SELECT r.*, gen.name AS generated_by_name, act.name AS activated_by_name, fin.name AS finalized_by_name, p.title AS source_policy_title FROM runbooks r LEFT JOIN users gen ON gen.id = r.generated_by LEFT JOIN users act ON act.id = r.activated_by LEFT JOIN users fin ON fin.id = r.finalized_by LEFT JOIN ir_policies p ON p.id = r.source_policy_id WHERE r.id = ?').get(runbookId);
+
+    if (!r) {
+      db.close();
+      return res.status(404).json({ error: 'runbook not found' });
+    }
+
+    const stepRows = db.prepare('SELECT s.*, comp.name AS completed_by_name FROM runbook_steps s LEFT JOIN users comp ON comp.id = s.completed_by WHERE s.runbook_id = ? ORDER BY s.step_number ASC').all(runbookId);
+    db.close();
+
+    const steps = stepRows.map((s) => ({
+      id: s.id,
+      stepNumber: s.step_number,
+      title: s.title,
+      instruction: s.instruction,
+      expectedOutcome: s.expected_outcome,
+      isCritical: s.is_critical === 1,
+      completedAt: s.completed_at,
+      completedBy: s.completed_by_name || s.completed_by,
+      completionNote: s.completion_note,
+      skipped: s.skipped === 1,
+      skipReason: s.skip_reason,
+    }));
+
+    return res.json({
+      runbook: {
+        id: r.id,
+        scenarioType: r.scenario_type,
+        title: r.title,
+        status: r.status,
+        sourcePolicyId: r.source_policy_id,
+        sourcePolicyVersion: r.source_policy_version,
+        sourcePolicyTitle: r.source_policy_title,
+        generatedAt: r.generated_at,
+        generatedBy: r.generated_by_name || r.generated_by,
+        activatedAt: r.activated_at,
+        activatedBy: r.activated_by_name || r.activated_by,
+        finalizedAt: r.finalized_at,
+        finalizedBy: r.finalized_by_name || r.finalized_by,
+        incidentId: r.incident_id,
+        notes: r.notes,
+      },
+      steps,
+    });
+  } catch (err) {
+    logger.error('Failed to fetch runbook', { runbookId, error: err.message });
+    return res.status(500).json({ error: 'failed to fetch runbook' });
+  }
 });
 
 module.exports = router;

--- a/server/services/notifications.js
+++ b/server/services/notifications.js
@@ -125,6 +125,27 @@ const EVENT_TYPES = {
     description: 'An analyst flagged a peer skill-share session for urgent conduct: slurs, explicit threats, sexual harassment, or content suggesting imminent harm. Both the flagged peer\'s identity and the flagger\'s identity are revealed to you. HR intervention is recommended. In-app delivery cannot be turned off for this event.',
     mandatoryInApp: true,
   },
+  runbook_generated: {
+    label: 'IR Recovery Runbook generated',
+    default: { in_app: 1, email: 0 },
+    description: 'A new IR Recovery Runbook has been generated from one of your team\'s uploaded policies. Review the steps in draft state, edit if needed, then activate when the incident is in progress.',
+  },
+  runbook_activated: {
+    label: 'IR Recovery Runbook activated',
+    default: { in_app: 1, email: 1 },
+    description: 'A team lead activated an IR Recovery Runbook — an incident response is now in progress and the runbook is being followed step by step. The dashboard banner will track active progress until the runbook is finalized. In-app delivery cannot be turned off for this event.',
+    mandatoryInApp: true,
+  },
+  runbook_step_completed: {
+    label: 'IR Recovery Runbook step completed',
+    default: { in_app: 0, email: 0 },
+    description: 'A step in an active runbook was marked complete. This event is off by default to avoid noise during fast-moving incidents — opt in if you want a real-time stream of step completions.',
+  },
+  runbook_finalized: {
+    label: 'IR Recovery Runbook finalized',
+    default: { in_app: 1, email: 1 },
+    description: 'A runbook was marked complete and the incident response is closed. The runbook record is immutable from this point and forms part of the incident audit trail.',
+  },
 };
 
 function isKnownEventType(eventType) {

--- a/server/services/runbook-parser.js
+++ b/server/services/runbook-parser.js
@@ -1,0 +1,129 @@
+// ═══════════════════════════════════════════════════════════════════════════════
+// FIREALIVE — IR Recovery Runbook Parser (Phase 1.4c)
+//
+// Extracts ordered steps from policy markdown text. Used by the runbooks
+// route to convert an uploaded ir_policies.content blob into a series of
+// structured runbook_steps rows.
+//
+// The parser handles three common policy markup patterns:
+//   1. Numbered list items: "1. Foo", "2) Bar"
+//   2. Markdown headers: "## Step 1: Foo", "### 2. Bar"
+//   3. Bulleted lists under a Steps/Procedure/Actions section header
+//
+// For each step, it extracts:
+//   - title:            first line, truncated to 200 chars
+//   - instruction:      full body text after the title, up to 5KB
+//   - expected_outcome: text following "Expected:" / "Outcome:" / "Result:"
+//                       markers, up to 1000 chars (nullable)
+//   - is_critical:      1 if title or first 500 chars of instruction contain
+//                       CRITICAL / MANDATORY / MUST, else 0
+//
+// If no recognizable structure is found, returns a single fallback step
+// directing the lead to add steps manually in draft state. This preserves
+// the contract that a runbook always has at least one step.
+// ═══════════════════════════════════════════════════════════════════════════════
+
+const NUMBERED_RE = /^\s*(\d+)[\.\)]\s+(.+)/;
+const HEADER_STEP_RE = /^#{2,6}\s+(?:Step\s+)?(\d+)[:\.]?\s+(.+)/i;
+const STEPS_HEADER_RE = /^#{2,6}\s+(steps?|procedures?|actions?|response|recovery)\b/i;
+const BULLET_RE = /^\s*[\*\-\+]\s+(.+)/;
+const OUTCOME_RE = /(?:^|\n)\s*(?:Expected|Outcome|Result)[:\.]?\s*(.+?)(?=\n\s*\n|$)/is;
+const CRITICAL_TITLE_RE = /\b(CRITICAL|MANDATORY|MUST)\b/i;
+const CRITICAL_BODY_RE = /\b(CRITICAL|MANDATORY|MUST NOT FAIL)\b/i;
+
+const MAX_TITLE_LENGTH = 200;
+const MAX_INSTRUCTION_LENGTH = 5000;
+const MAX_OUTCOME_LENGTH = 1000;
+const CRITICAL_BODY_SCAN_LENGTH = 500;
+
+function parsePolicyToSteps(policyContent, scenarioType) {
+  if (typeof policyContent !== 'string' || policyContent.length === 0) {
+    return [fallbackStep()];
+  }
+
+  const lines = policyContent.split(/\r?\n/);
+  const steps = [];
+  let currentStep = null;
+  let inStepsSection = false;
+
+  for (const line of lines) {
+    const headerStepMatch = line.match(HEADER_STEP_RE);
+    if (headerStepMatch) {
+      pushStep(steps, currentStep);
+      currentStep = { title: headerStepMatch[2].trim(), instructionLines: [] };
+      inStepsSection = true;
+      continue;
+    }
+
+    const numberedMatch = line.match(NUMBERED_RE);
+    if (numberedMatch) {
+      pushStep(steps, currentStep);
+      currentStep = { title: numberedMatch[2].trim(), instructionLines: [] };
+      inStepsSection = true;
+      continue;
+    }
+
+    if (STEPS_HEADER_RE.test(line)) {
+      inStepsSection = true;
+      continue;
+    }
+
+    if (inStepsSection) {
+      const bulletMatch = line.match(BULLET_RE);
+      if (bulletMatch && !currentStep) {
+        currentStep = { title: bulletMatch[1].trim(), instructionLines: [] };
+        continue;
+      }
+      if (bulletMatch && currentStep) {
+        currentStep.instructionLines.push('• ' + bulletMatch[1].trim());
+        continue;
+      }
+      if (line.trim() && currentStep) {
+        currentStep.instructionLines.push(line);
+      }
+    }
+  }
+  pushStep(steps, currentStep);
+
+  if (steps.length === 0) {
+    return [fallbackStep()];
+  }
+
+  return steps;
+}
+
+function pushStep(steps, s) {
+  if (!s) return;
+  const title = (s.title || '').slice(0, MAX_TITLE_LENGTH);
+  const instructionRaw = (s.instructionLines || []).join('\n').trim();
+  const instruction = (instructionRaw || title).slice(0, MAX_INSTRUCTION_LENGTH);
+  if (!title && !instruction) return;
+
+  let expectedOutcome = null;
+  const outcomeMatch = instruction.match(OUTCOME_RE);
+  if (outcomeMatch) {
+    expectedOutcome = outcomeMatch[1].trim().slice(0, MAX_OUTCOME_LENGTH);
+  }
+
+  const titleHit = CRITICAL_TITLE_RE.test(title);
+  const bodyHit = CRITICAL_BODY_RE.test(instruction.slice(0, CRITICAL_BODY_SCAN_LENGTH));
+  const isCritical = (titleHit || bodyHit) ? 1 : 0;
+
+  steps.push({
+    title,
+    instruction,
+    expected_outcome: expectedOutcome,
+    is_critical: isCritical,
+  });
+}
+
+function fallbackStep() {
+  return {
+    title: 'Review the source policy and add steps manually',
+    instruction: 'The runbook generator could not extract structured steps from this policy. Open the source policy in the IR Simulator policies tab, identify the recovery procedure, and add steps to this runbook in draft state before activating.',
+    expected_outcome: null,
+    is_critical: 0,
+  };
+}
+
+module.exports = { parsePolicyToSteps };


### PR DESCRIPTION
## Summary

Phase 1.4c Part 1. Server-side foundation for org-policy-driven
IR Recovery Runbooks. Builds on the precursor PR that consolidated
ir_policies into a canonical table — runbooks now reference real
foreign keys to real policy data.

## What "org-policy-driven" means

The team lead uploads IR policy documents (markdown, PDF text,
plain text) via the existing IR Simulator policies infrastructure.
For each scenario type (ransomware, data exfiltration, insider
threat, etc.), the lead picks one of those uploaded policies as
the source. The parser extracts ordered steps from the policy
text and creates a runbook in 'draft' status. The lead reviews
and edits before activating.

During an active incident, analysts and leads tick off steps with
optional completion notes. Critical steps (flagged by the parser
based on CRITICAL/MANDATORY/MUST keywords) require an explicit
skip reason if skipped. When the incident is over, the runbook
is finalized and becomes part of the immutable audit trail —
preserving exactly which version of which policy was followed.

This is not a generic textbook IR playbook generator. It produces
runbooks from the team's actual procedures.

## Schema

Three new tables (commit 1):

- runbooks — instances with status lifecycle (draft → active →
  completed | cancelled), foreign keys to ir_policies(id) and
  users(id), source_policy_version captured at generation so
  historical runbooks always know exactly which policy version
  was followed
- runbook_steps — ordered steps with title, instruction,
  expected_outcome, is_critical, completion tracking, skip
  tracking with reason
- runbook_scenario_policies — junction table mapping scenario
  types to ir_policies, with is_default flag for pre-selecting a
  policy when generating

Five indexes covering the queries we need: status filtering,
scenario filtering, source policy lookup, ordered step retrieval,
default-policy-per-scenario lookup.

## Notification events

Four new EVENT_TYPES (commit 2):

- runbook_generated (in_app on, email off)
- runbook_activated (in_app on, email on, mandatoryInApp:true —
  same pattern as panic-mode and tier-3 abuse flags)
- runbook_step_completed (off by default — opt-in only, to avoid
  drowning leads in noise during fast-moving incidents)
- runbook_finalized (in_app on, email on)

## Routes

server/routes/runbooks.js with nine endpoints:

- POST /api/runbooks/generate — generate from policy
- GET /api/runbooks — list with status/scenario filters
- GET /api/runbooks/:id — fetch with full step list
- POST /api/runbooks/:id/activate — draft → active
- POST /api/runbooks/:id/finalize — active → completed
- POST /api/runbooks/:id/cancel — draft|active → cancelled
- POST /api/runbooks/:id/steps/:stepId/complete — any role
- POST /api/runbooks/:id/steps/:stepId/skip — lead/admin
- GET /api/runbooks/scenarios/:type/policies — list tagged +
  untagged policies for a scenario
- POST /api/runbooks/scenarios/:type/policies — tag policy with
  optional isDefault (auto-clears other defaults for that
  scenario)
- DELETE /api/runbooks/scenarios/:type/policies/:policyId — untag

All endpoints emit audit log events with descriptive metadata so
incident timelines can be reconstructed from audit alone.

## Parser

server/services/runbook-parser.js extracts ordered steps from
three common policy markup patterns: numbered lists, markdown
headers ("## Step 1: Foo"), and bulleted lists under
Steps/Procedure/Actions section headers. Each step gets a title,
instruction body, optional expected_outcome (from "Expected:" /
"Outcome:" / "Result:" markers), and is_critical flag from
keyword detection.

If the parser finds no recognizable structure, returns a single
fallback step directing the lead to add steps manually in draft
state. This preserves the contract that runbooks always have at
least one step.

The parser lives in its own service module so it can be tested
in isolation and reused by future scenario generators.

## Commits

1. db: add runbooks, runbook_steps, runbook_scenario_policies tables
2. notifications: add 4 runbook event types (generated/​​​​​​​​​​​​​​​​