### PR TITLE
Release v1.0.12 — IR Recovery Runbooks + TTX Generator

### DIFF
--- a/frontend/firealive-mc.jsx
+++ b/frontend/firealive-mc.jsx
@@ -252,7 +252,7 @@ function RoleSelect({onSelect}) {
     <div style={{minHeight:"100vh",background:"#050810",display:"flex",alignItems:"center",justifyContent:"center",fontFamily:"'DM Sans',sans-serif"}}>
       <style>{CSS}</style>
       <div style={{maxWidth:520,width:"100%",padding:"0 24px",animation:"fadeIn 0.5s ease"}}>
-        <M style={{color:C.td,letterSpacing:2,textTransform:"uppercase",fontSize:9,display:"block",marginBottom:16,textAlign:"center"}}>FireAlive v1.0.0 · AGPL-3.0</M>
+        <M style={{color:C.td,letterSpacing:2,textTransform:"uppercase",fontSize:9,display:"block",marginBottom:16,textAlign:"center"}}>FireAlive v1.0.12 · AGPL-3.0</M>
         <h1 style={{fontSize:26,fontWeight:300,color:"#E8EDF5",textAlign:"center",marginBottom:8,fontFamily:"'Fraunces',serif"}}>FireAlive</h1>
         <M style={{color:C.tm,display:"block",textAlign:"center",marginBottom:36,lineHeight:1.6}}>Select your role to proceed to authentication.<br/>Each role loads a separate application with distinct data access.</M>
         <div style={{display:"grid",gridTemplateColumns:"1fr 1fr",gap:16}}>
@@ -339,7 +339,7 @@ function LoginScreen({role, onLogin, onBack}) {
             <div style={{marginBottom:14}}><M style={{color:C.tm,marginBottom:4,display:"block"}}>Password</M><input type="password" value={pass} onChange={e=>setPass(e.target.value)} placeholder="••••••••" maxLength={128} style={{width:"100%",padding:10,background:"rgba(255,255,255,0.03)",border:`1px solid ${C.b}`,borderRadius:8,color:C.t,fontSize:12}}/></div>
             {error&&<div style={{fontSize:11,color:C.d,marginBottom:12}}>{error}</div>}
             <Btn primary style={{width:"100%"}} onClick={handleCreds} disabled={loading}>{loading?"Authenticating...":"Sign In"}</Btn>
-            <M style={{color:C.td,display:"block",textAlign:"center",marginTop:16}}>FireAlive v1.0.0 AGPL-3.0</M>
+            <M style={{color:C.td,display:"block",textAlign:"center",marginTop:16}}>FireAlive v1.0.12 AGPL-3.0</M>
           </Card>
         )}
 

--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
   "name": "firealive",
-  "version": "1.0.11",
-  "fuseCounter": 4,
-    "buildId": "20260501.1",
+  "version": "1.0.12",
+  "fuseCounter": 5,
+  "buildId": "20260501.2",
   "description": "FireAlive — SOC Analyst Wellbeing Platform. Burnout-aware ticket routing, peer skill-share, post-incident wellness, skills assessments, and team health monitoring with privacy-first architecture.",
   "main": "server/index.js",
   "directories": {


### PR DESCRIPTION
## Summary

v1.0.12 release. Two major feature phases land in this version:

  - Phase 1.4c (Parts 1 + 2): IR Recovery Runbook
  - Phase 1.4d: TTX Generator

Plus the precursor PR that consolidated `ir_policies` into a
canonical table. Fuse counter bumps from 4 to 5.

## Phase 1.4c — IR Recovery Runbook

Org-policy-driven runbooks built from the team's own uploaded IR
policies. Leads upload policies via the IR Simulator; the parser
extracts ordered steps from the policy text and produces a draft
runbook. Lead reviews, activates during a real incident,
finalizes when complete. Critical steps (parsed from CRITICAL /
MANDATORY / MUST keywords in the policy) require explicit skip
reason. Source policy version is captured at generation time so
the audit trail always knows exactly which version of which
policy was followed.

Active runbooks raise a persistent dashboard banner (same visual
language as the Phase 1.4b tier-3 abuse flag banner) and fire a
mandatoryInApp notification to all leads/admins.

Scenario-to-policy tagging UI lets leads pre-select default
policies per scenario type (ransomware, credential compromise,
ddos, etc.) for faster generation during real incidents.

Three new DB tables (runbooks, runbook_steps,
runbook_scenario_policies) with proper foreign keys to
ir_policies and users. The precursor PR consolidated ir_policies
from a phantom 5-column table + team_config JSON blobs into a
canonical 13-column table with content hashes, version tracking,
and soft delete — so these foreign keys resolve cleanly and old
data migrates idempotently on first startup.

Four new notification event types: runbook_generated,
runbook_activated (mandatoryInApp), runbook_step_completed
(off by default — opt-in only), runbook_finalized.

Server: schema, parser service, route file with 9 endpoints.
MC frontend: list view, generation modal with policy picker,
detail view with metadata + step list + action buttons,
dashboard banner, scenario tagging modal, DELETE method added
to api helper.

## Phase 1.4d — TTX Generator

Tabletop exercise document generator. Curated scenario library
(4 scenarios x 3 difficulty levels) covering ransomware, data
exfiltration, credential compromise via vishing, and cloud
account compromise. Generates Situation Manuals (SitMans) for
the facilitator to bring to the in-person tabletop and blank
After-Action Report (AAR) templates for the team to fill in
afterwards.

Both PDF (printable, archival) and DOCX (editable) output
formats. Document structure follows HSEEP Volume IV and NIST
SP 800-84 conventions.

Each generation emits an audit log entry. The audit trail is the
compliance breadcrumb proving the team is running tabletops.

No DB schema, no session state, no notifications — TTX is a
discussion-based exercise that happens in person, around a
table. The system's job is to produce the document the lead
carries into the meeting and the template the team fills in
after.

Two new dependencies: docx@^9.0.0 and pdfkit@^0.15.0, both pure
JS, MIT-licensed, AGPL-compatible.

## Other changes

  - Pre-login version strings bumped from v1.0.0 (12 releases
    stale) to v1.0.12. Known structural issue: the runtime
    version fetch landed in v1.0.10 but only updated
    authenticated screens — pre-login screens fall back to
    hardcoded strings that go stale on every release. Filed
    as future tech debt: switch pre-login version display to
    fetch from /api/system/health (public endpoint).
  - Five additional stale v1.0.0 references in exported
    document generators (Terraform, CloudFormation, Pulumi,
    capacity report) noted but not fixed in this release —
    same tech debt category as above.

## Fuse counter

Bumped from 4 to 5. The anti-rollback protection prevents
downgrade to a v1.0.11 deploy on a database that has already
migrated to the v1.0.12 schema.

## Build ID

20260501.2

## Phase merges in this release

  - phase-1.4c-precursor-policy-table-cleanup
  - phase-1.4c-part-1-runbook-server
  - phase-1.4c-part-2-runbook-mc
  - phase-1.4d-ttx-generator

## Out of scope (deferred)

  - AC frontend support for runbook execution. Currently leads
    drive runbooks from the MC; analysts can technically be
    assigned to runbooks via the existing role pattern but no
    AC view exists yet. A future small phase or release will
    add a read-only runbook view + step-complete capability
    to the AC.
  - Multi-policy runbooks. One policy per runbook for now.
  - Step reordering/​​​​​​​​​​​​​​​​