### PR TITLE
Phase 1.4: mount /api/iam and /api/upskilling routes

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -120,6 +120,8 @@ app.use('/api/query', authMiddleware(['lead', 'admin']), require('./routes/query
 app.use('/api/auth/password', require('./routes/password'));
 app.use('/api/restore', authMiddleware(['admin']), require('./routes/restore'));
 app.use('/api/ooda', authMiddleware(['analyst', 'lead', 'admin']), require('./routes/ooda'));
+app.use('/api/iam', authMiddleware(['lead', 'admin']), require('./routes/iam'));
+app.use('/api/upskilling', authMiddleware(['lead', 'admin']), require('./routes/upskilling'));
 app.use('/api/runbooks', authMiddleware(['analyst', 'lead', 'admin']), require('./routes/runbooks'));
 app.use('/api/ttx', authMiddleware(['analyst', 'lead', 'admin']), require('./routes/ttx'));
 app.use('/api/inbox', authMiddleware(['analyst', 'lead', 'admin']), require('./routes/notifications-inapp'));

--- a/server/routes/iam.js
+++ b/server/routes/iam.js
@@ -1,0 +1,85 @@
+// ═══════════════════════════════════════════════════════════════════════════════
+// FIREALIVE — IAM Offboarding Routes
+// GET  /api/iam/check-absence   — return analysts whose IAM check is overdue
+// POST /api/iam/confirm-status  — confirm analyst as active, OR mark offboarded
+// ═══════════════════════════════════════════════════════════════════════════════
+//
+// These routes support periodic recertification of analyst accounts. The team
+// lead receives a list of analysts whose last_iam_check is older than the
+// configured interval (or who have never been checked) and either confirms
+// each one as still active (resetting the timer) or marks them offboarded.
+// Offboarded analysts have active=0 and offboarded_at set; they no longer
+// appear in routing or peer-share queues.
+// ═══════════════════════════════════════════════════════════════════════════════
+
+const router = require('express').Router();
+const { getDb } = require('../db/init');
+const { auditLog } = require('../middleware/audit');
+const { logger } = require('../services/logger');
+
+// ── List analysts due for IAM recertification ────────────────────────────────
+router.get('/check-absence', (req, res) => {
+  try {
+    const db = getDb();
+    // Read configured interval (hours) from team_config; default 168 (1 week)
+    const cfgRow = db.prepare("SELECT value FROM team_config WHERE key = 'iam_config'").get();
+    const intervalHours = (() => {
+      if (!cfgRow) return 168;
+      try {
+        const cfg = JSON.parse(cfgRow.value);
+        const h = Number(cfg.intervalHours);
+        return Number.isFinite(h) && h > 0 ? h : 168;
+      } catch { return 168; }
+    })();
+    const cutoff = new Date(Date.now() - intervalHours * 3600000).toISOString();
+    const users = db.prepare(`
+      SELECT id, pseudonym, last_iam_check
+      FROM users
+      WHERE role = 'analyst' AND active = 1
+    `).all();
+    db.close();
+    const overdue = users.filter(u => !u.last_iam_check || u.last_iam_check < cutoff);
+    auditLog(req.user?.id, 'IAM_CHECK_ABSENCE', `total=${users.length} overdue=${overdue.length}`, req.ip);
+    res.json({
+      checked: true,
+      total: users.length,
+      intervalHours,
+      needsReview: overdue.map(u => ({ id: u.id, pseudonym: u.pseudonym, lastCheck: u.last_iam_check })),
+    });
+  } catch (err) {
+    logger.error('IAM check-absence error', { error: err.message });
+    res.status(500).json({ error: 'Failed to check IAM absence' });
+  }
+});
+
+// ── Confirm analyst status (active or offboard) ──────────────────────────────
+router.post('/confirm-status', (req, res) => {
+  const { analystId, action } = req.body || {};
+  if (!analystId || typeof analystId !== 'string') {
+    return res.status(400).json({ error: 'analystId is required' });
+  }
+  if (action !== 'active' && action !== 'offboard') {
+    return res.status(400).json({ error: 'action must be "active" or "offboard"' });
+  }
+  try {
+    const db = getDb();
+    const user = db.prepare("SELECT id, role FROM users WHERE id = ?").get(analystId);
+    if (!user) { db.close(); return res.status(404).json({ error: 'Analyst not found' }); }
+    if (user.role !== 'analyst') { db.close(); return res.status(400).json({ error: 'User is not an analyst' }); }
+    const now = new Date().toISOString();
+    if (action === 'offboard') {
+      db.prepare("UPDATE users SET active = 0, offboarded_at = ? WHERE id = ?").run(now, analystId);
+      auditLog(req.user?.id, 'IAM_OFFBOARD', `analyst=${analystId}`, req.ip);
+    } else {
+      db.prepare("UPDATE users SET last_iam_check = ? WHERE id = ?").run(now, analystId);
+      auditLog(req.user?.id, 'IAM_CONFIRMED_ACTIVE', `analyst=${analystId}`, req.ip);
+    }
+    db.close();
+    res.json({ success: true, analystId, action, at: now });
+  } catch (err) {
+    logger.error('IAM confirm-status error', { error: err.message });
+    res.status(500).json({ error: 'Failed to update analyst status' });
+  }
+});
+
+module.exports = router;

--- a/server/routes/upskilling.js
+++ b/server/routes/upskilling.js
@@ -1,0 +1,85 @@
+// ═══════════════════════════════════════════════════════════════════════════════
+// FIREALIVE — Upskilling Schedule Routes
+// GET  /api/upskilling/schedules — list all analyst upskilling time slots
+// POST /api/upskilling/schedule  — save or update one analyst's upskilling slot
+// ═══════════════════════════════════════════════════════════════════════════════
+//
+// Upskilling slots are protected windows during the workday when an analyst
+// is taken out of the routing pool to focus on training (assessments, KB
+// review, peer skill-share). Each analyst gets one configurable slot. The
+// scheduler service honors these slots when distributing tickets.
+//
+// Slots are stored in team_config under keys of the form
+// "upskilling_schedule_<analystId>" so they survive routing-cap changes and
+// roll up into the team-level config snapshots used by /api/restore.
+// ═══════════════════════════════════════════════════════════════════════════════
+
+const router = require('express').Router();
+const { getDb } = require('../db/init');
+const { auditLog } = require('../middleware/audit');
+const { logger } = require('../services/logger');
+
+const SLOT_PATTERN = /^([01]\d|2[0-3])-([01]\d|2[0-3])$/;
+const KEY_PREFIX = 'upskilling_schedule_';
+
+// ── List all upskilling schedules ────────────────────────────────────────────
+router.get('/schedules', (req, res) => {
+  try {
+    const db = getDb();
+    const rows = db.prepare(`
+      SELECT key, value FROM team_config WHERE key LIKE ?
+    `).all(`${KEY_PREFIX}%`);
+    db.close();
+    const schedules = rows.map(r => {
+      try {
+        const data = JSON.parse(r.value);
+        return {
+          analystId: r.key.slice(KEY_PREFIX.length),
+          slot: data.slot,
+          updatedAt: data.updatedAt,
+          updatedBy: data.updatedBy,
+        };
+      } catch { return null; }
+    }).filter(Boolean);
+    res.json({ schedules });
+  } catch (err) {
+    logger.error('List upskilling schedules error', { error: err.message });
+    res.status(500).json({ error: 'Failed to list upskilling schedules' });
+  }
+});
+
+// ── Save or update one analyst's upskilling slot ─────────────────────────────
+router.post('/schedule', (req, res) => {
+  const { analystId, slot } = req.body || {};
+  if (!analystId || typeof analystId !== 'string') {
+    return res.status(400).json({ error: 'analystId is required' });
+  }
+  if (!slot || typeof slot !== 'string' || !SLOT_PATTERN.test(slot)) {
+    return res.status(400).json({ error: 'slot is required in HH-HH format (e.g. "14-15")' });
+  }
+  const [startHour, endHour] = slot.split('-').map(Number);
+  if (endHour !== (startHour + 1) % 24) {
+    return res.status(400).json({ error: 'slot must be a single one-hour window (e.g. "14-15")' });
+  }
+  try {
+    const db = getDb();
+    const user = db.prepare("SELECT id, role FROM users WHERE id = ?").get(analystId);
+    if (!user) { db.close(); return res.status(404).json({ error: 'Analyst not found' }); }
+    if (user.role !== 'analyst') { db.close(); return res.status(400).json({ error: 'User is not an analyst' }); }
+    const now = new Date().toISOString();
+    const payload = JSON.stringify({ slot, updatedAt: now, updatedBy: req.user?.id || null });
+    db.prepare(`
+      INSERT INTO team_config (key, value, updated_by)
+      VALUES (?, ?, ?)
+      ON CONFLICT(key) DO UPDATE SET value = excluded.value, updated_by = excluded.updated_by, updated_at = datetime('now')
+    `).run(`${KEY_PREFIX}${analystId}`, payload, req.user?.id || null);
+    db.close();
+    auditLog(req.user?.id, 'UPSKILLING_SCHEDULED', `analyst=${analystId} slot=${slot}`, req.ip);
+    res.json({ success: true, analystId, slot, updatedAt: now });
+  } catch (err) {
+    logger.error('Save upskilling schedule error', { error: err.message });
+    res.status(500).json({ error: 'Failed to save upskilling schedule' });
+  }
+});
+
+module.exports = router;


### PR DESCRIPTION
## Summary

Adds two new mounted route files for analyst lifecycle management:
IAM recertification and upskilling schedules. Replaces unmounted,
broken endpoints in routes/v054-features.js with proper mounted
implementations following the codebase's standard route patterns.

## What's new

**routes/iam.js** — mounted at `/api/iam`, auth: lead/admin.

  - `GET /api/iam/check-absence` — returns analysts whose
    last_iam_check is older than the configured interval. Reads
    interval from team_config["iam_config"].intervalHours,
    defaults to 168 hours (1 week).
  - `POST /api/iam/confirm-status` — accepts {analystId, action}
    where action is "active" (resets last_iam_check) or
    "offboard" (sets active=0, records offboarded_at). Both log
    to the audit trail.

**routes/upskilling.js** — mounted at `/api/upskilling`, auth:
lead/admin.

  - `GET /api/upskilling/schedules` — returns all configured
    analyst upskilling slots from team_config rows with the
    "upskilling_schedule_" key prefix.
  - `POST /api/upskilling/schedule` — accepts {analystId, slot}
    where slot is HH-HH format (e.g. "14-15"). Validates the slot
    is exactly one consecutive hour. Saves via atomic upsert.

**server/index.js** — mounts the two new routes alongside
`/api/ooda` and before the legacy v0XX-features mount block.

## Why this PR exists

The MC's offboarding tab calls `/api/v054/iam/confirm-status` and
the upskilling-hour tab calls `/api/v054/upskilling/schedule`.
Both currently 404 because routes/v054-features.js is not mounted
in server/index.js — and even if it were mounted, it imports
middleware (requireAuth, requireRole) that doesn't exist in this
codebase. The endpoints have been broken since the route file was
written.

This PR ships proper mounted replacements for those four endpoints,
following the same conventions used by every other route in routes/
(authMiddleware mount, getDb pattern, auditLog calls, structured
error handling).

## What this PR does NOT do

- Does not delete routes/v054-features.js. That file still contains
  endpoints (helper-pay, pseudonym rotation, ticketing config,
  SOAR config, compliance reports, etc.) that need real
  implementations in future phases. Deleting it would lose the
  roadmap of features that need building.

- Does not delete routes/v059-features.js. Same reasoning —
  contains metrics/CEF, audit integrity, regression runner, cloud
  package generator, CI/CD config that all need real
  implementations in future phases.

- Does not re-point the MC frontend from /api/v054/* to the new
  /api/iam/* and /api/upskilling/* paths. That's a follow-up
  frontend commit. Until that lands, the MC will still 404 on
  those calls — just like before this PR — but now the backend
  is ready to receive properly-pointed calls.

## Commits

1. Phase 1.4: create server/routes/iam.js for analyst recertification
2. Phase 1.4: create server/routes/upskilling.js for analyst training slots
3. Phase 1.4: mount /api/iam and /api/upskilling routes
