### PR TITLE
docs: add FEATURE-GUIDE.md

### DIFF
--- a/FEATURE-GUIDE.md
+++ b/FEATURE-GUIDE.md
@@ -1,0 +1,1022 @@
+# FireAlive Feature Guide
+
+A plain-language reference to every feature in the FireAlive suite. For each feature: what it's for, who uses it, when, and the workflow to use it.
+
+This guide is bundled with every FireAlive distribution and is also accessible via the Help tab in each application (Management Console, Analyst Client, Global Dashboard).
+
+If you're new to FireAlive, start with **The Big Picture** below.
+
+---
+
+## The Big Picture
+
+FireAlive is a SOC analyst burnout-prevention platform. Security Operations Centers burn out their analysts at brutal rates — turnover, errors, mental health damage. FireAlive sits inside the team's existing SOC tooling stack and intervenes at the points where burnout actually happens: ticket assignment, peer support, training, post-incident recovery, shift transitions.
+
+Three apps make up the suite:
+
+- **Analyst Client (AC)** — runs on each analyst's workstation. Where the analyst sees their own signals, asks for help, takes care of themselves.
+- **Management Console (MC)** — runs on the team lead's workstation. Where the lead sees aggregate team health (no individual burnout data), configures the platform, runs operations.
+- **Global Dashboard (GD)** — runs on the CISO's workstation. Read-only view aggregating across multiple regional MCs. Executive-level visibility without the operational details.
+
+A regional **Server** sits behind the AC/MC. A separate **GD Server** aggregates from regional MCs.
+
+The whole thing is built on three privacy commitments:
+- **Tier-3 data** (individual burnout signals) is encrypted on the analyst's client and never seen by the lead
+- **Tier-1 data** (team-level aggregates) is what the lead sees — averages, never individuals
+- **Pseudonyms** decouple analyst identity from burnout data at the database layer
+
+---
+
+# MANAGEMENT CONSOLE (Team Lead)
+
+## Operations group — the lead's daily workspace
+
+### Actions
+**What it's for:** The lead's daily action queue. The platform reads aggregate team signals (utilization spikes, capacity overload, extended stress patterns) and surfaces priority prompts for the lead to act on. Each prompt cites the underlying research so the lead understands why this is being flagged.
+
+**Workflow:**
+1. Lead logs in at the start of shift
+2. Lands on Actions tab
+3. Sees prompts ranked by severity (red = high, amber = medium, gray = low)
+4. Each prompt shows the issue, suggested response, supporting research citation
+5. Lead can adjust prompt depth (full / compact / minimal) for their attention level
+6. Lead either acts on a prompt or silences it (if they've decided not to act)
+
+### Team Overview
+**What it's for:** The lead's at-a-glance team capacity view. Shows workload metrics — utilization %, ticket counts, capacity caps — but never burnout signals. The deliberate boundary: the lead sees enough to manage capacity but not so much that they're surveilling individuals' wellbeing.
+
+**Workflow:**
+1. Lead opens Team Overview
+2. Sees four headline metrics (Team Health score, Avg Utilization, # Over Capacity, # Extended)
+3. Per-analyst capacity cards show utilization bars, ticket counts, complexity caps
+4. Lead spots someone over capacity, makes routing adjustments in the Routing tab
+
+### Routing & SOAR
+**What it's for:** Where the lead configures FireAlive's burnout-aware ticket routing. The lead connects to their existing SOAR platform (so FireAlive can write ticket assignments) and ticketing system (read-only — to see queue metadata). Once connected, FireAlive routes tickets to analysts with the highest capacity scores rather than dumping them on whoever's available.
+
+**Workflow:**
+1. Lead enters SOAR platform credentials, ticketing platform credentials
+2. Tests the connection
+3. Sets per-analyst complexity caps (tier 1 might cap at complexity 2, tier 3 might handle complexity 5)
+4. Activates burnout-aware routing
+5. From now on, when a ticket comes in, FireAlive checks each analyst's burnout signals and capacity, then writes the ticket assignment back to SOAR
+6. Live feed shows routing decisions as they happen
+
+### Shift Handoff
+**What it's for:** Structured shift-to-shift handoffs to prevent the information loss that causes errors during transitions. Research shows handoff errors peak in the last two hours of shifts when analysts are most fatigued. This formalizes the handoff so context doesn't get dropped.
+
+**Workflow:**
+1. Outgoing lead at end of shift opens Shift Handoff tab
+2. Sees an auto-generated summary (current team health, active routing adjustments, active recovery protocols, open high-priority incidents, staffing notes)
+3. Adds free-text context for the incoming lead — what's in progress, anything unusual
+4. Submits handoff (optionally also sends a notification to the incoming lead)
+5. Incoming lead opens the same tab at start of their shift, reads the handoff, knows where things stand
+
+### SLA
+**What it's for:** Track Mean Time to Acknowledge (MTTA) and Mean Time to Resolve (MTTR). When SLA performance degrades, FireAlive correlates with team capacity to help the lead distinguish "the team is slow because they're overloaded" from "the team is slow because they're undertrained" — different problems, different fixes.
+
+**Workflow:**
+1. Lead opens SLA tab
+2. Sees current MTTA/MTTR vs targets, broken down by priority level
+3. If SLAs are slipping, the dashboard shows whether team capacity is the cause
+4. Lead either redistributes tickets (capacity problem) or assigns training (skill problem)
+
+### Automation
+**What it's for:** Where the team lead registers the automated systems that analysts can offload routine, low-level tickets to. This is NOT for monitoring the systems that feed tickets in — it's the opposite. Analysts in their AC have a Delegate feature where they can identify repetitive ticket patterns (false positives they keep closing, low-level routine work that doesn't need human judgment) and send those tickets to an automated system. The lead uses this Automation tab to tell FireAlive which automated systems are available for that purpose. The configuration propagates from MC to all connected ACs so analysts know which systems they can delegate to.
+
+This is also the integration point for FireAlive to work alongside other anti-burnout tools. Research has shown that most anti-burnout programs in the industry are built around automating boring, routine tasks. So the Automation tab is also where the lead connects FireAlive to those existing automation programs the org already runs — SOAR's automated response, dedicated ticket-automation tools, AI triage systems, anything that takes shitjob busywork off the analyst's plate. Boosting human analyst capacity is the goal; this tab is where that boost gets wired in.
+
+**Workflow:**
+1. Lead identifies the automated systems in use across the org (SOAR auto-response actions, dedicated ticket-automation platforms, AI triage systems, other anti-burnout tools)
+2. Opens Automation tab in MC
+3. Adds each system: name, type, what it can handle, capacity ceiling
+4. Configuration propagates to every connected AC
+5. Analysts in the AC's Delegate tab now see the available automation targets
+6. When an analyst delegates a ticket pattern, it routes to the appropriate automated system the lead registered
+
+### Fail-Open Routing
+**What it's for:** Like an IPS configured to fail-open: if FireAlive's burnout routing engine itself fails, the system reverts to the SOAR's native distribution rather than blocking ticket flow. The SOC keeps defending the network even when FireAlive is down.
+
+**Workflow:**
+1. Lead opens Fail-Open Routing tab
+2. Configures health check interval (e.g. every 10 seconds)
+3. Sets max time in fail-open mode before requiring manual intervention (e.g. 30 minutes — long enough to ride out a glitch, short enough to force escalation if FireAlive is genuinely broken)
+4. If routing engine fails health check: tickets revert to SOAR-native routing immediately, lead is notified
+5. When FireAlive comes back, routing resumes automatically
+
+### Auto-Disable Routing
+**What it's for:** During a major incident requiring all hands, the lead shouldn't have to remember to manually disable burnout-aware routing — that would slow them down at the worst time. This feature auto-disables routing when high-severity triggers are detected, so every available analyst gets tickets immediately. Routing restores after the incident is over.
+
+**Workflow:**
+1. Lead pre-configures triggers in advance (P1 ticket, SIEM critical alert, SOAR escalation)
+2. Sets cooldown — how long after the trigger clears before routing re-enables (e.g. 60 minutes)
+3. When an actual incident hits: trigger fires, routing auto-disables, all analysts receive tickets, lead's dashboard shows banner
+4. After cooldown, routing automatically resumes burnout-aware behavior
+
+### Runbook Generator
+**What it's for:** Generate runbooks for incidents and failures involving FireAlive itself — not for general incident response. The org already has runbooks for ransomware, phishing, etc.; FireAlive doesn't try to replace those. What FireAlive's adoption introduces is a new attack surface: an MC-AC communication channel, AC clients on every analyst workstation, encrypted Tier-3 data, signal feeds that could be poisoned, peer chat infrastructure. That's the surface this runbook generator addresses.
+
+The scenarios in this generator are FireAlive-specific:
+- Compromise of FireAlive that claims theft of burnout data
+- Attacker uses compromised AC clients to inject false burnout stats, tricking the routing engine into reducing tickets across the team and tripping the tripwire
+- Compromise of MC-AC communication channel
+- Analyst client integrity failure
+- Server crash with degraded HA
+- Peer chat infrastructure compromise
+- Backup system tampering
+
+For each, the generator produces a step-by-step runbook covering identification, containment, eradication, restore (often including the workflow of tearing down a compromised app instance and using the Restore feature to rebuild from backup), and lessons-learned. The intent is to get the team thinking through how their attack surface has expanded by adopting FireAlive and how to defend that new surface.
+
+**Workflow:**
+1. Lead opens Runbook Generator (proactively, before any incident)
+2. Picks a FireAlive-specific scenario from the dropdown
+3. Clicks Generate
+4. Sees the multi-step runbook
+5. Exports as JSON, PDF, or DOCX, or prints
+6. Keeps the printed runbook somewhere accessible during an incident — when systems may be down
+
+This is preparation material. During an actual incident, the team executes from the printed copy.
+
+---
+
+## Analysts & Wellbeing group — managing the people
+
+### Skills Matrix
+**What it's for:** Aggregate view of where each analyst is on the skill ladder. The lead sees who's progressing across multiple core skills — useful for spotting promotion candidates and identifying team-wide skill gaps. When an analyst crosses proficiency thresholds across 3+ skills, a "level-up signal" surfaces here as recognition (not as an automatic promotion trigger — the lead decides).
+
+**Workflow:**
+1. Lead opens Skills Matrix at the end of the quarter for review
+2. Sees each analyst's current tier, top progressing skills, and any level-up signals
+3. For analysts with level-up signals: lead schedules a growth conversation
+4. Lead can silence signals they've already acknowledged or acted on
+
+### Assessments
+**What it's for:** Targeted skill assessments the team lead creates to verify whether specific analysts can handle specific things. Distinct from the AC-side baseline assessments analysts take when they first start using FireAlive (those populate the gaps display and feed the upskilling training engine, all visible only to the analyst). Lead-created targeted assessments are different: the lead identifies a specific skill the team needs (Kubernetes Security, malware analysis, buffer overflow handling, etc.), creates an assessment alert for that skill, and pushes it to one or more analyst's ACs.
+
+The actual assessment module is hosted on an external platform — HackTheBox, TryHackMe, LetsDefend, Cyberdefenders, SANS, etc. FireAlive doesn't host the modules. Instead, the assessment alert sent to the AC tells the analyst where to go to take it. The analyst completes the module on the external platform, then submits a completion report (link, score, date) back into the AC. The result populates the analyst's gap display and training suggestions in the AC, AND — unlike the AC-side baseline assessments — the lead sees the result. So lead-created targeted assessments serve two purposes: they show the analyst where they stand on a skill, AND they give the lead visibility into who can or can't handle a specific scenario.
+
+**Workflow:**
+1. Lead identifies a skill that's needed (e.g. "Kubernetes security incident response")
+2. Clicks "+ Create Assessment"
+3. Names it for the skill: "Kubernetes Security Skills Assessment"
+4. Picks the target tier (Tier 1 / Tier 2 / Tier 3) — assessment skill list filters to tier-appropriate options
+5. Selects skills from the taxonomy via checkboxes (or adds custom skills for org-specific topics)
+6. Specifies the external module: which platform (TryHackMe, HackTheBox, etc.), which module, the URL
+7. Picks which analyst(s) to assign it to (or the whole team)
+8. Submits — analyst's AC shows an Assessment Required notification at the top of the appropriate tab with directions on where to go
+9. Analyst goes to the external module, completes it, submits the completion report back through their AC
+10. Lead sees results come back, color-coded (green = strong, amber = on threshold, red = gap)
+11. Gap areas auto-create training recommendations for that analyst — no further action needed
+12. Lead now knows which analysts can handle that scenario, which may inform routing, ticket assignment for related incidents, or upskilling priorities
+
+### Certifications
+**What it's for:** Lead-side view of analysts' broader industry certifications (CompTIA, ISACA, GIAC, etc.) beyond the platform's training-linked certs. Used for identifying team-wide gaps and planning upskilling. There's also an MC-side cert input wizard so the lead can input certs themselves — useful when an analyst hands the lead a physical cert as proof of completion and the lead prefers to record it directly rather than asking the analyst to submit through their AC.
+
+**Workflow (analyst submits, lead verifies — typical):**
+1. Analyst registers a cert in their AC (uploads file, enters verification number)
+2. Lead opens Certifications tab in MC
+3. Sees aggregated view: which certs each analyst has, expirations
+4. Verifies new cert submissions, identifies team-wide gaps
+
+**Workflow (lead inputs directly):**
+1. Analyst hands the lead a physical certificate of completion
+2. Lead opens Certifications tab → "+ Add Cert for Analyst"
+3. Picks the analyst, enters cert details, uploads scanned copy
+4. Cert is recorded against that analyst's profile
+
+### CISM Retro (Incident Retrospectives)
+**What it's for:** Structured post-incident support based on Critical Incident Stress Management research. After major incidents — ransomware, breaches, active intrusions — analysts experience acute stress comparable to emergency services responders. This module activates a recovery protocol: lighter queues for affected analysts, peer support availability, automated follow-up check-ins at 24hr / 72hr / 2 weeks.
+
+**Workflow:**
+1. Major incident wraps up
+2. Lead opens CISM Retro tab
+3. Clicks "Activate New Recovery Protocol"
+4. Enters incident reference, severity, selects which analysts were involved
+5. Picks queue reduction duration (this shift / 24hr / 72hr / 1 week)
+6. Activates — affected analysts get lighter queues, peer support is enabled in their AC, follow-up check-ins scheduled
+7. Lead can mark the protocol complete or send manual follow-ups
+8. Participation is voluntary — analysts can decline anything, the lead just makes it available
+
+### Peer Skill-Share Configuration
+**What it's for:** Where the lead configures the peer-to-peer help system between analysts. Sets when peer chat can be used (block during heads-down hours? allow during shift?), session duration limits, and crucially the Helper Pay configuration — analysts who help peers earn points convertible to PTO or cash.
+
+**Workflow:**
+1. Lead opens Peer Skill-Share Configuration
+2. Configures scheduling restrictions (allow during shift toggle, block hours, max session duration, inactivity timeout)
+3. Configures Helper Pay: USD per 100 points, PTO minutes per 100 points, tier multipliers (L3 senior helpers earn more), redemption minimum, approval workflow
+4. Reviews helper recognition leaderboard (opt-in only — helpers choose if they're visible)
+5. Reads chat disclaimer — the lead can NOT edit it; this is the analysts' protected space
+
+### Pseudonyms
+**What it's for:** The architectural privacy commitment: every analyst gets a permanent UUID and rotating pseudonym (Analyst-Falcon, Analyst-Kestrel, etc.). All burnout metrics, peer chat messages, reduced-routing requests, and wellness signals are stored against the pseudonym — never the real name. If the database is breached, attackers see "Analyst-Falcon is in elevated burnout" rather than a real person. The mapping (UUID → pseudonym → real name) is exported as an encrypted file the lead stores offline.
+
+**Workflow:**
+1. Lead opens Pseudonyms tab on initial setup
+2. System generates pseudonyms for each analyst from a stable list (animals, etc.)
+3. Lead exports the mapping as an encrypted file — stores it on a USB key in the safe, NOT on the network
+4. Periodically rotates pseudonyms (quarterly, after offboarding events) — UUIDs stay the same so historical data is preserved
+5. When the lead needs to know which real person Analyst-Falcon is (e.g. for a CISM retro), they look up the offline mapping
+
+### IR Simulator (lead-side, ooda_mgmt)
+**What it's for:** The lead uploads their organization's IR policies, playbooks, and after-action reports here. The system parses each policy and generates OODA-loop training scenarios that analysts then practice in their AC. The point: analysts train on **their own org's procedures**, not generic textbook procedures. A new analyst joining shouldn't have to figure out "how does THIS team handle phishing" through trial-by-fire — they should practice it in the simulator first.
+
+**Workflow:**
+1. Lead opens IR Simulator (Policy Management) tab
+2. Uploads the org's ransomware response playbook (text or file)
+3. Names it, tags type (incident_response / playbook / runbook / policy / procedure)
+4. Saves — system parses the policy and generates one or more OODA scenarios from it
+5. Lead can also pick a scenario type (ransomware, phishing, data_exfil, insider_threat, apt, ddos, supply_chain, credential_compromise) and have the system generate a scenario from that policy targeted at that scenario type
+6. Repeats for each major IR policy the org has
+7. Now analysts in their AC can practice these scenarios. After completion, the analyst sees the actual policy that was used to generate the scenario.
+
+### Proactive Breaks
+**What it's for:** Based on Sonnentag's recovery research: prolonged high-severity ticket work without breaks accelerates burnout exponentially. This feature monitors workload patterns and suggests breaks BEFORE burnout signals appear — preventive rather than reactive. The lead approves the suggestion before it goes to the analyst (so analysts aren't being told what to do by the system without lead oversight).
+
+**Workflow:**
+1. Lead configures: "After N hours of continuous high-severity work, suggest a break of M minutes"
+2. Toggles "Require Team Lead approval before sending"
+3. Analyst hits the threshold — system pings the lead
+4. Lead reviews ("yes this analyst should take a break") and approves
+5. Analyst gets an affirming notification: "You've been working hard. Consider a 15-minute break."
+6. Analyst can take the break or continue — their choice
+
+### Upskilling Hour
+**What it's for:** Dedicate one hour per shift to professional development. During that hour, the analyst's queue is paused — they can study, peer skill-share, do training, work on certifications. The research is unambiguous: companies that fund on-the-clock development have lower turnover than companies that demand analysts upskill on their own time.
+
+**Workflow:**
+1. Lead opens Upskilling Hour tab
+2. Configures: "1 hour during the 8th hour of shift" (so it's at the end, but configurable)
+3. Sets minimum coverage requirement (e.g. "75% of team must be on-shift" — so the whole team isn't simultaneously upskilling)
+4. Assigns each analyst to a slot (different times so coverage stays adequate)
+5. Optionally integrates with HR scheduling system (UKG/Workday/ADP)
+6. During an analyst's slot, their AC pauses ticket routing and shows training resources / peer chat options
+
+### Offboarding
+**What it's for:** Securely deprovision analysts who leave or change roles. Their historical aggregate data stays for team metrics, but personally identifiable links are severed. All keys/sessions/peer-chat schedules are revoked. Integrates with IAM (so when HR offboards in the IdP, FireAlive picks it up) and SOAR (so offboarding orchestration is automatic).
+
+**Workflow:**
+1. Either: lead manually offboards (picks analyst, reason: voluntary departure / termination / role change / transfer)
+2. Or: IAM offboarding detector runs on schedule (every 4hr / 8hr / daily / weekly), checks the IdP for users no longer present, surfaces them for the lead to confirm
+3. Lead confirms either "still active" (resets the recertification timer) or "offboard"
+4. On offboard: account marked inactive, sessions revoked, pseudonym removed from rotation, historical aggregate data preserved under the UUID
+
+### Sync Interval
+**What it's for:** Control how often analyst clients transmit burnout metrics to the server. Default is every 15 minutes (batch mode) — continuous sync wastes bandwidth and provides no real benefit. Adaptive mode ramps up sync frequency during incidents and slows down when stable.
+
+**Workflow:**
+1. Lead opens Sync Interval tab once during setup
+2. Sets base interval (15 minutes default)
+3. Toggles adaptive mode (recommended — speeds up during incidents)
+4. Sets urgent event threshold — for panic events / critical incidents, push immediately rather than wait for next interval
+5. Saves — applies to all connected analyst clients
+
+### Client Notifications
+**What it's for:** Configure how each user (lead and analyst) receives notifications from FireAlive. Per notification type, each user chooses delivery: email, SMS, desktop notification, in-app inbox, multiple, or off. The inbox is one channel option among many — for users who want a place to find missed notifications. It's not mandatory.
+
+**Workflow:**
+1. Each user (lead AND analyst) opens their notification preferences
+2. Per notification type (assessment assigned, retro scheduled, peer request, panic broadcast, helper points awarded, etc.) chooses delivery: in-app inbox / email / SMS / desktop notification / multiple / off
+3. Notifications fire through the channels they chose — never through ones they didn't
+4. The inbox is one channel option — for users who want a place to find missed notifications
+
+---
+
+## Integrations group — connecting to the rest of the SOC stack
+
+### Integrations Health Dashboard
+**What it's for:** Real-time status of every external system FireAlive depends on — SOAR, ticketing, SIEM, EDR, IdP, KMS, etc. If any disconnect, the lead is alerted before it causes routing failures.
+
+**Workflow:**
+1. Lead glances at this tab daily as part of shift opening
+2. All integrations show green = healthy
+3. If something turns red or amber: lead clicks through to the specific integration tab to investigate
+
+### SIEM Integration
+**What it's for:** Push FireAlive's metrics to the org's SIEM in CEF format so SOC management tooling has visibility into FireAlive's own health. Optionally: restrict the burnout metrics widget to the lead's SIEM dashboard only — protect team morale from analysts seeing aggregate burnout numbers that could feel demoralizing.
+
+**Workflow:**
+1. Lead configures SIEM endpoint
+2. Toggles which metrics get pushed (system health, security events, burnout aggregates with visibility scope)
+3. SIEM ingests the CEF stream
+4. SIEM dashboards now show FireAlive-specific health alongside everything else the SOC monitors
+
+### EDR File Inspection
+**What it's for:** Every file uploaded to FireAlive (config restores, IR policy uploads, IaC imports, app updates) gets scanned by the org's EDR before being processed. Prevents a malicious file from reaching FireAlive's internals through the upload path.
+
+**Workflow:**
+1. Lead configures EDR provider in this tab
+2. Whenever someone uploads a file anywhere in FireAlive: system pauses, calls EDR scanner with file
+3. Scanner returns clean → upload proceeds
+4. Scanner returns malicious → upload rejected, lead notified, audit log entry
+
+### Threat Hunting Integrations
+**What it's for:** Open FireAlive itself to inspection by the org's threat-hunting tooling — XDR behavioral monitoring, ATP, Next-Gen AV, MSP scanners. So the org can detect if FireAlive itself is compromised. Companion to EDR (which scans files coming IN); this enables tools to scan FireAlive's own behavior.
+
+**Workflow:**
+1. Lead configures provider per category
+2. Hunting tools now have authorized access to scan FireAlive
+3. Findings flow back through normal hunting workflow
+
+### Client Provisioning
+**What it's for:** Analysts never install the AC themselves — the lead provisions clients via enterprise deployment tooling. Prevents rogue installs and ensures every AC starts with the right config (server endpoint, enrollment token).
+
+**Workflow:**
+1. Lead opens Client Provisioning tab
+2. Configures deployment tool (Intune / Jamf / SCCM / Workspace ONE / Ansible)
+3. Per analyst: enters name, tier, shift, target hostname, IP
+4. Clicks "Provision Client" — system generates a config.json + enrollment token, packages it for the deployment tool
+5. Deployment tool pushes the AC to the analyst's machine
+6. Analyst opens the AC, authenticates via IAM + MFA, baseline calibration begins
+
+### AI/ML Integrations
+**What it's for:** External AI/ML systems FireAlive can integrate with for the burnout prediction engine, scenario generation in the IR Simulator, signal analysis. Some are internal (always required), some optional.
+
+**Workflow:**
+1. Lead configures provider, endpoint, API key
+2. AI/ML features start using the configured integration
+
+---
+
+## Security group
+
+### IAM
+**What it's for:** Connect FireAlive to the org's identity provider (Okta, Azure AD, PingOne, OneLogin) so analysts authenticate with their corporate credentials. SSO via SAML or OIDC, with LDAP/AD as fallback. When IAM is integrated, MFA enforcement happens at the IdP — FireAlive trusts what the IdP says.
+
+**Workflow:**
+1. Lead opens IAM tab on initial setup
+2. Picks IdP type, enters config (Entity ID, IdP metadata URL, etc.)
+3. Tests connection
+4. Once configured: analysts log in via SSO, no separate FireAlive password needed
+
+### MFA (built-in, for non-IAM deployments)
+**What it's for:** TOTP/WebAuthn MFA wizard for deployments that don't have enterprise IAM. Walks through QR code setup. Skipped if the IdP already enforces MFA.
+
+**Workflow:**
+1. Lead opens MFA tab
+2. Picks method (TOTP via authenticator app, WebAuthn for hardware keys)
+3. Scans QR or registers WebAuthn token
+4. Configures grace logins (how many can happen before enforcement) and remember-device duration
+
+### API Keys
+**What it's for:** Programmatic access to FireAlive for SOAR/SIEM integrations. Each key is role-scoped — least privilege. A key for "team health metrics streaming to SIEM" doesn't get access to anything else.
+
+**Workflow:**
+1. Lead opens API Keys
+2. Clicks "+ New Key"
+3. Names it ("splunk-cef-stream"), picks scope ("read team health"), sets expiry
+4. Receives the key, copies it into the SOAR/SIEM config
+5. Periodically reviews key usage (last used timestamps), revokes any that are unused or compromised
+
+### Access Control
+**What it's for:** Align FireAlive with the org's overall access control model — RBAC (Role-Based), MAC (Mandatory), DAC (Discretionary), ABAC (Attribute-Based). Different access models change how FireAlive should behave internally for things like permission inheritance, role-to-action mapping, attribute evaluation, and policy enforcement order. The lead picks the model their org uses; FireAlive adapts its internal enforcement to fit.
+
+This feature also handles concurrent session limits, session timeouts, and per-action MFA requirements.
+
+**Workflow:**
+1. Lead opens Access Control during setup
+2. Picks the org's access control model (RBAC / MAC / DAC / ABAC)
+3. Sets max concurrent sessions per user, session timeout
+4. Picks any access pattern presets (e.g. "Zero-Trust Strict", "Standard Enterprise", "Pilot Phase Permissive")
+5. FireAlive's internal session enforcement and authorization logic adjusts to match the chosen model
+
+### Auth Logs
+**What it's for:** Track every authentication attempt — successful and failed — for both MC and AC. Useful for detecting brute-force, credential stuffing, or unauthorized access attempts. When IAM is integrated, this supplements (doesn't replace) the IdP's auth logs.
+
+**Workflow:**
+1. Lead opens Auth Logs to investigate a suspicious activity report
+2. Filters by user, IP, time range
+3. Sees pattern (e.g. 50 failed logins from one IP in 2 minutes)
+4. Lead configures brute-force threshold for automatic detection
+5. Future attempts crossing threshold trigger automatic lockout + alert
+
+### KMS (Enterprise Key Management)
+**What it's for:** Centralize FireAlive's encryption key lifecycle in the org's enterprise KMS — AWS KMS, Azure Key Vault, HashiCorp Vault, Thales, Entrust. All encryption tiers (Tier-3 analyst data, Tier-1 team data, peer chat E2EE, backups, audit log signing) get their keys managed through KMS with HSM backing and automated rotation.
+
+**Workflow:**
+1. Lead opens KMS tab on initial setup or when migrating from default keys
+2. Picks KMS provider, enters endpoint/ARN, key ID/alias
+3. Configures rotation policy
+4. FireAlive switches from default-key mode to KMS-backed mode
+5. From now on, every encryption operation uses keys from KMS
+
+### WiFi Policy
+**What it's for:** Enforce minimum WiFi security on analyst clients. WPA2-Personal (PSK) is vulnerable to brute force; WPA2-Enterprise with 802.1X/EAP is the SOC minimum. The AC checks the local WiFi before connecting and blocks if non-compliant.
+
+**Workflow:**
+1. Lead opens WiFi Policy
+2. Sets minimum protocol (WPA2-Enterprise default, WPA3-Enterprise stricter)
+3. AC enforcement: when an analyst's machine joins a non-compliant WiFi (e.g. coffee shop with WPA2-Personal), the AC won't connect to the FireAlive server until they switch to a compliant network
+
+### Posture Assessment
+**What it's for:** Like 802.1X NAC and MDM posture checks: at app startup the AC verifies the workstation meets minimum security posture (TLS version, OS patch level, EDR running, etc.) before connecting to the management console. Non-compliant devices are warned or blocked until remediated.
+
+**Workflow:**
+1. Lead opens Posture Assessment, configures checks
+2. Sets minimum TLS version, grace period before blocking
+3. AC enforcement: on every connection (or first launch only), runs posture check, reports compliance to MC, blocks if failed
+
+### Tripwire
+**What it's for:** Detection for a specific attack pattern: if a large percentage of analysts simultaneously enter "reduced routing" status, it could indicate compromised analyst clients are coordinately requesting load reduction to degrade SOC response capacity. The tripwire auto-disables burnout routing and alerts the lead to investigate.
+
+**Workflow:**
+1. Lead configures threshold (e.g. "if >40% of analysts go into reduced routing within 5 minutes")
+2. Normal operation: occasional analyst goes reduced — no alarm
+3. Attack scenario: 5+ analysts request reduction in quick succession — tripwire fires
+4. Burnout routing auto-disables, lead gets urgent notification, lead investigates
+
+### Compromise Scan
+**What it's for:** Orchestrate compromise tests across analyst clients. Each AC runs 10-point self-diagnostics (binary integrity, memory analysis, network connections, configuration drift, audit log continuity, TLS pinning, API tokens, filesystem integrity, EDR status, encryption keys) and returns a signed report. Lead uses this after a tripwire event or any time client compromise is suspected.
+
+**Workflow:**
+1. Lead opens Compromise Scan
+2. Either picks a single client or "Scan All Clients"
+3. ACs run their 10-point checks (takes a couple minutes)
+4. Results come back with pseudonyms — lead sees per-client pass/fail breakdown
+5. Failed checks → lead investigates that client, may rotate its pseudonym, reprovision, or escalate
+
+### Log Integrity
+**What it's for:** Audit logs are append-only with SHA-256 hash chain. The application prevents deletion. This tab monitors the chain for missing logs (gaps suggest tampering or partition events) and triggers SOAR alerts on detection.
+
+**Workflow:**
+1. Lead glances at this tab — green status = chain intact
+2. If a gap is detected: SOAR fires, lead clicks in to see the gap range
+3. Lead investigates whether it's a partition (system was offline) or tampering (someone tried to delete entries)
+
+### Regression Test
+**What it's for:** Run an automated test suite verifying every integration and control still functions after an update. Before deploying a new FireAlive version, the lead runs regression to catch broken integrations, missing connections, or deprecated features.
+
+**Workflow:**
+1. After applying an update or making major config changes
+2. Lead opens Regression Test, clicks Run
+3. ~40 tests execute (auth flows, encryption round-trips, KMS round-trips, FK integrity, fuse counter, audit chain, peer-share E2E, IAM offboarding, etc.)
+4. Pass/fail report — lead investigates failures
+
+### TTX Generator
+**What it's for:** Generate Tabletop Exercise (TTX) documents — a Situation Manual (SitMan) for the facilitator to bring to a tabletop meeting, plus a blank After-Action Report (AAR) template for the team to fill in afterwards. Curated scenario library (ransomware, data exfiltration, credential compromise via vishing, cloud account compromise) at three difficulty levels. Output formats: PDF (printable, archival) and DOCX (editable). Each generation is logged as compliance evidence.
+
+**Workflow:**
+1. Lead schedules a tabletop exercise
+2. Opens TTX Generator, picks scenario, difficulty (easy/intermediate/hard), format (PDF/DOCX)
+3. Downloads SitMan — brings to the tabletop meeting
+4. Downloads AAR template — for the team to fill in afterwards
+5. After the tabletop: completed AAR goes in the team fileshare; the audit log entry from generation proves to auditors that the exercise was conducted
+
+---
+
+## Infrastructure group
+
+### Cloud & IaC
+**What it's for:** Generate Infrastructure-as-Code artifacts to deploy FireAlive on the org's cloud platform. Supports AWS, Azure, GCP, and **privacy-first European/Swiss providers** (Hetzner Cloud, OVHcloud, Exoscale) for orgs that need data sovereignty (no US CLOUD Act jurisdiction). Outputs Terraform, CloudFormation (AWS only), Pulumi, or Docker Compose.
+
+**Workflow:**
+1. Lead picks target cloud provider, IaC tool, secrets manager
+2. Clicks Generate
+3. Receives a downloadable bundle with: deployable IaC files, secrets-management mapping (env vars → KMS paths), README with deployment steps
+4. Hands the bundle to platform engineering for deployment
+
+### Virtualization
+**What it's for:** Hypervisor / container orchestration integration (VMware vSphere, Hyper-V, Docker, Kubernetes) for orgs that deploy FireAlive in their existing virtual infrastructure. Configures resource pool, datastore, host placement.
+
+**Workflow:**
+1. Lead picks deployment target type
+2. Enters API endpoint for hypervisor or K8s control plane
+3. FireAlive deploys into the configured virtualization infrastructure with the right resource constraints
+
+### SDN
+**What it's for:** Configure FireAlive for distributed SOC environments where analysts, automation, and SIEM infrastructure span multiple sites connected via SD-WAN or SDN fabrics. Tells FireAlive which CIDRs are which sites so routing and access controls are network-aware.
+
+**Workflow:**
+1. Lead picks SDN platform (Cisco ACI, VMware NSX, etc.)
+2. Configures controller endpoint, primary/secondary site CIDRs, SD-WAN overlay
+3. FireAlive's network awareness adjusts to the SDN topology
+
+### SASE / ZTNA
+**What it's for:** Integrate FireAlive into the org's SASE platform. FireAlive can operate as a SECaaS offering or connect through ZTNA, CASB, SWG components.
+
+**Workflow:**
+1. Lead picks SASE provider (Zscaler, Palo Alto Prisma, Netskope, Cato)
+2. Configures ZTNA endpoint, FWaaS policy, optional CASB
+3. FireAlive's network access adjusts to SASE policy enforcement
+
+### High Availability
+**What it's for:** HA configuration with two supported topologies: active/passive (one server handles all traffic with a passive standby continuously replicating; failover happens when active fails health checks) and active/active (both servers handle traffic simultaneously, sharing session state). Synchronous replication keeps data consistent. The MC is decoupled from the backend — it talks to whichever server is currently reachable behind the load balancer, so failover is transparent to the lead.
+
+For larger deployments needing more than two servers, use the Cluster / Scaling feature instead.
+
+**Workflow:**
+1. Lead opens HA Configuration
+2. Picks mode (active/passive or active/active)
+3. Configures secondary server endpoint, replication interval, health check interval/path
+4. For active/active: configures shared session store (Redis required)
+5. Once configured: replication is continuous
+6. If active fails (active/passive): passive promotes within seconds, MC reconnects automatically, lead is notified — but the SOC keeps operating
+
+### Cluster / Scaling
+**What it's for:** For large deployments (hundreds or thousands of analysts), deploy FireAlive as a multi-node active-active cluster. Distributes load, supports horizontal scaling, supports segmenting different team-lead views.
+
+**Workflow:**
+1. Lead opens Cluster tab
+2. Picks cluster mode (active-active multi-node)
+3. Sets node count, session store (Redis required for active-active), worker threads per node
+4. Cluster comes online, load balancer distributes incoming connections
+
+### CI/CD
+**What it's for:** Generate CI/CD pipeline configurations so orgs can build their own customized FireAlive distributions. Because FireAlive is open-source, orgs are free to fork, modify, and run their own custom versions tailored to their specific SDN setup, automation stack, integrations, etc. The CI/CD generator is the bridge: instead of starting from a generic upstream release and re-applying every customization, the org uses this feature to output a pipeline config that captures their CURRENT production configuration as the baseline. They can then build whatever new tools or modifications they want on top of that already-configured baseline.
+
+It also serves a second purpose: contributing back upstream. Orgs that find security holes, build useful new features, or improve existing ones can use the same CI/CD feature to push their commits back to the public FireAlive GitHub repo. That accelerates collaborative development of the platform — better features, better security, broader applicability — and increases the platform's collective effectiveness in the war against analyst burnout and malicious attackers.
+
+Supports GitHub Actions, GitLab CI, Jenkins, CircleCI. Pipelines include lint, regression test, security scan, build, sign, deploy, and fuse counter check.
+
+**Workflow (custom org build):**
+1. Org's developers want to extend FireAlive with org-specific tooling
+2. Lead opens CI/CD tab in MC
+3. Picks CI platform
+4. Clicks Generate — output is a pipeline config that reflects the current production configuration (integrations, automations, custom settings already configured in this org's MC)
+5. Org's developers commit the pipeline config to their internal repo
+6. They build their additional tooling on top of the configured baseline rather than from a generic upstream release
+7. CI runs automatically on every push, deploys to the org's lab/production environments
+
+**Workflow (upstream contribution):**
+1. Org developer finds a bug or builds a useful feature
+2. Same CI/CD generator outputs a pipeline that targets the public FireAlive GitHub repo
+3. Developer pushes commits through that pipeline back to the upstream project
+4. Upstream maintainers review and integrate
+
+---
+
+## Data & Backup group
+
+### Backup
+**What it's for:** Encrypted backups (AES-256-GCM) with per-data-type destination routing. The lead can route backups to one location, audit logs to another, forensic exports to a third — different retention and access requirements for each.
+
+**Workflow:**
+1. Lead opens Backup tab
+2. For each data type (database, audit logs, forensic exports): configures destination, retention, schedule
+3. Backups run on schedule, encrypted, hashed for integrity
+4. Lead can trigger manual backups or restore from any backup
+
+### Backup Schedules
+**What it's for:** Configure multiple backup schedules with regulatory-framework presets (GDPR, HIPAA, SOX, PCI-DSS, etc.). Picking a regulatory preset auto-configures retention/encryption/destination to match that framework's requirements.
+
+**Workflow:**
+1. Lead opens Backup Schedules
+2. Adds a schedule: type, frequency, time, destination, retention
+3. Picks regulatory preset if applicable — auto-configures the rest to match the framework
+
+### Restore
+**What it's for:** Restore from backup or revert configuration. Two modes: internal (revert to a recent FireAlive backup of this same install) and external (restore from a backup stored on a network share, NAS, S3, Azure, SFTP).
+
+The internal mode is for routine reverts — someone messed up the configuration, or some data became noticeably corrupted, and the lead wants to roll back without tearing down the whole install.
+
+The external mode is for compromise recovery. If an AC, MC, or GD has been compromised, the safest workflow is: tear down the compromised app instance entirely, install a fresh clean copy, then use the external Restore feature on that fresh copy to pull configurations, integrations, and data back from a known-good external backup. This avoids re-introducing the compromise that might still be lurking in the original install's filesystem or local backups.
+
+**Workflow (internal — routine revert):**
+1. Lead notices configuration mistake or data corruption
+2. Opens Restore tab → Internal
+3. Picks the restore point from the list of recent internal backups
+4. Confirms restore
+5. System restores in place
+
+**Workflow (external — compromise recovery):**
+1. Compromise detected (via Compromise Scan, threat hunting, etc.)
+2. Lead tears down the compromised app instance — uninstall, wipe filesystem, validate clean state of host
+3. Install a fresh copy of FireAlive from verified source
+4. Open Restore tab → External
+5. Configure source: type (network share / NAS / S3 / Azure / SFTP), path, decryption key
+6. Verifies integrity of the external backup, executes restore
+7. System rebuilds from the trusted external backup with original configurations, integrations, and data
+
+### Data Sovereignty / Geo-Fencing
+**What it's for:** Multinational SOC support. Each analyst client gets a country tag and the regulatory framework that applies (GDPR, PIPEDA, LGPD, etc.). Enforces data residency, blocks logins from unexpected countries, applies the right framework to that client's data.
+
+**Workflow:**
+1. Lead opens Data Sovereignty
+2. Per client: tags country, regulatory framework, data residency requirement
+3. Toggles "block logins from countries not matching client's location"
+4. From now on: a German-tagged client can't be logged into from China — IP-based block, lead notified
+
+### Legal Hold
+**What it's for:** Export data for legal hold / e-discovery requirements. Hashes data for integrity verification, formats for ESI repositories, generates chain of custody automatically.
+
+**Workflow:**
+1. Lead receives legal hold request from counsel
+2. Opens Legal Hold tab
+3. Configures ESI repository path, hash algorithm, export format
+4. Triggers export — system produces hashed export with chain-of-custody documentation
+5. Hands export to counsel, retention is enforced indefinitely until hold is released
+
+---
+
+## Reports & Compliance group
+
+### Report Engine
+**What it's for:** Scheduled depersonalized team-level reports for management or compliance. NEVER includes individual analyst names — tier/shift aggregates only. AI analysis backed by the platform's research knowledge base, so reports cite peer-reviewed studies behind the recommendations. Output formats: PDF (printable, archival) and DOCX (editable), generated using the same document generator as the TTX feature.
+
+**Workflow:**
+1. Lead opens Report Engine
+2. Configures: frequency, day, format (PDF/DOCX), email recipients
+3. On schedule (or on-demand "Generate Report" click): system generates the report
+4. Two delivery options:
+   - Click Generate Report → system produces the PDF/DOCX and opens a download window
+   - Or system emails the report to the configured recipients
+5. Recipients see team trends, training needs, capacity issues — but never individual data
+
+### Compliance
+**What it's for:** Generate framework-specific compliance reports against the running system. Picks a framework (NIST CSF, ISO 27001, SOC 2, HIPAA, GDPR, DORA, CCPA, PIPEDA, LGPD, PDPA, APPI, POPIA, NIS2, CPS 234, Cyber Essentials, FISMA), system runs real checks against actual app state, produces an audit-ready report. Output formats: PDF and DOCX, generated using the same document generator as the TTX feature.
+
+**Workflow:**
+1. Auditor announces audit
+2. Lead picks the relevant framework
+3. Clicks Generate Report
+4. System runs control checks against actual app state — access control, encryption, audit trail, authentication, config management, IR, data protection, network, backups, notifications
+5. Generated report opens a download window (PDF or DOCX) and can also be emailed to recipients
+6. Lead reviews, hands to auditor
+
+### Recertification
+**What it's for:** Periodic review of all accounts, integrations, assessments, and configurations. Quarterly recommended. Ensures stale accounts are removed, integrations are still current, settings still appropriate. Triggers a workflow rather than a one-time view.
+
+**Workflow:**
+1. Quarterly: system reminds the lead it's time for recertification
+2. Lead opens Recertification, sees due items
+3. Walks through each: account by account, integration by integration
+4. Marks each as "still valid" or "needs review/removal"
+5. System logs the recertification — proof to auditors that periodic review is happening
+
+### Knowledge Base
+**What it's for:** The research knowledge base behind FireAlive's burnout-prevention features. Hundreds of peer-reviewed entries (R001, R017, R037, etc.) cited throughout the platform — the AI burnout prediction engine, the lead-side intervention prompts, the analyst-side signal interpretations. Visible to leads here so they (and any auditor) can verify that FireAlive's recommendations come from real peer-reviewed scientific research, not from a profit incentive to sell features that just sound like they'd work.
+
+The KB is curated. It is not open to anyone to update — that would be an attack vector for malicious actors to inject articles that accelerate burnout rather than prevent it. There's a button to add KB peer-reviewed burnout articles, but for now that's restricted to the upstream maintainer (Peter Mancina). The KB is updated on a quarterly or annual basis with the latest scientific research on burnout prevention, distributed via FireAlive version updates.
+
+**Workflow:**
+1. Lead clicks a citation in a prompt or report
+2. KB opens to the entry, showing full citation, summary, and how it informs the relevant FireAlive feature
+3. Or lead browses categories (burnout, skill development, post-incident recovery)
+4. Or generates an API key for developers building org-specific training content
+
+### Playbooks (SOAR Playbook / Runbook Generator)
+**What it's for:** Generate investigation and response playbooks for security incidents involving the FireAlive platform itself. The lead exports these to import into the SOAR system, or prints them as runbooks. Distinct from the Runbook Generator (which produces failure-and-compromise procedures for FireAlive) — these are SOAR-style automation playbooks for ongoing incident response involving FireAlive.
+
+**Workflow:**
+1. Lead opens Playbooks
+2. Picks incident type
+3. System generates the playbook with steps (some automated, some manual)
+4. Lead exports — drops into SOAR or prints
+
+### Risk Register Asset Generator
+**What it's for:** Generate a risk register entry for FireAlive itself as an organizational asset. Includes quantitative metrics (Asset Value, Exposure Factor, Single Loss Expectancy, Annual Rate of Occurrence, Annualized Loss Expectancy) and qualitative impact/likelihood. Crucially, it factors in the **human capital risk of NOT using burnout prevention** — the cost side of analyst turnover.
+
+**Workflow:**
+1. Risk team asks lead for a register entry on FireAlive
+2. Lead opens Risk Register Asset Generator
+3. System produces entry with AV/EF/SLE/ARO/ALE plus the inverse calculation: cost of turnover and replacement training if FireAlive weren't deployed
+4. Lead exports and submits to the risk register
+
+### Human Impact Risk Report
+**What it's for:** Quantified report on the human capital cost of analyst burnout and the burnout-incident relationships specific to this org. Two purposes:
+
+First, it's used to justify FireAlive's value to executives in dollar terms — annualized turnover cost, replacement training cost, and the inverse "what would this cost without FireAlive" calculation.
+
+Second — and more importantly — it tracks in granular detail which TYPES of incidents burn out which TYPES of analysts the fastest. This lets the org make informed risk-management decisions beyond just adopting FireAlive. For example, if low-tier analysts are burning out fast because they get an avalanche of mindless repetitive tickets, the report can highlight that risk and recommend the org invest in more automated systems so those tickets can be delegated. If senior analysts are burning out from prolonged credential-compromise investigations, the report can recommend the org invest in better identity-protection infrastructure to reduce the volume of those incidents. So the report doesn't just sell FireAlive — it actively informs executive-level investment decisions about what infrastructure, automation, and protection layers will most reduce burnout in this specific org.
+
+**Workflow:**
+1. Quarterly business review or budget cycle
+2. Lead opens Human Impact Risk Report, generates
+3. Sees per-incident-type cost breakdown ("ransomware events drive +18% exit risk for tier-1 analysts, $61,200 annualized cost")
+4. Sees recommended infrastructure investments correlated with high-risk incident types
+5. Presents to executives — informs both FireAlive's value and other risk-mitigation investments
+
+### Query Tool
+**What it's for:** Two query tools combined — SIEM query generator (produces copy-pasteable queries for the org's SIEM platform from templates) and an internal app query tool (run injection-protected queries against FireAlive's own data).
+
+**Workflow (SIEM Query Generator):**
+1. Lead needs a SIEM query for "all login attempts to FireAlive in last 24h"
+2. Opens Query Tool, picks template, picks SIEM platform (Splunk/Elastic/QRadar/Sentinel)
+3. Gets the query as text, copies it into the SIEM
+
+**Workflow (Internal Query Tool):**
+1. Lead needs to investigate something specific in FireAlive's own data
+2. Picks data source, regex filter
+3. Runs query — system parameterizes, strips injection attempts, returns results
+
+---
+
+## Configuration group
+
+### Feature Toggles
+**What it's for:** Enable or disable individual features across the platform. Disabling a feature does NOT remove it from the UI — instead, the feature's text becomes greyed out (still visible so users know it exists), all action buttons and config inputs are disabled, and a message appears explaining that the feature is administratively disabled and that to use it requires re-enabling in the Feature Toggles tab. Same behavior in MC and AC.
+
+This way users can still see what FireAlive offers without being confused about why a feature suddenly disappeared.
+
+**Workflow:**
+1. Lead opens Feature Toggles
+2. Sees features grouped by category (Wellbeing, Operations, Development, Integrations, Security, Management)
+3. Toggles a feature off — the feature's tab text greys out, controls disable, an "administratively disabled" message replaces the workflow content
+4. Toggles back on — feature returns to fully active state
+
+### Burnout Alerts
+**What it's for:** Alert thresholds for team-level burnout metrics. When the team's aggregate health drops below a threshold, or capacity overload exceeds a threshold, the lead is alerted via configured channels. Distinct from app performance alerts (CPU, memory) which are in Monitoring.
+
+**Workflow:**
+1. Lead configures thresholds on initial setup
+2. Picks notification channels (per the Client Notifications config)
+3. When team metrics cross thresholds, alert fires through chosen channels
+
+### MSP Multi-Tenancy
+**What it's for:** For Managed Service Providers monitoring multiple client organizations on one FireAlive deployment. Each tenant gets isolated encryption keys, separate audit trails, scoped API keys. Cross-tenant data access is blocked architecturally.
+
+**Workflow:**
+1. MSP sets up FireAlive
+2. Opens MSP Multi-Tenancy, adds first tenant
+3. Repeats per client org
+4. Each tenant runs in isolation: tenant A's analysts never see tenant B's data, even though both run on the same server
+
+### Global Dashboard
+**What it's for:** Configure this regional MC to push aggregate data to a Global Dashboard (CISO-level view). Anonymized aggregate only — no individual analyst data crosses the region boundary. The GD is a companion app, not a controller.
+
+**Workflow:**
+1. CISO sets up GD, generates RO API key for this region
+2. Regional lead opens Global Dashboard tab in MC
+3. Pastes GD ingest endpoint, RO API key
+4. MC starts pushing aggregate data to GD on schedule
+5. CISO sees regional health alongside other regions
+
+### Updates
+**What it's for:** Update orchestration that does NOT force production updates automatically. The lead controls where update packages get sent — straight to production, to a lab environment, or to another repository for review. Once an update has been retrieved and sent to the lab, the org's existing change-management process takes over: their developers do regression testing and security testing in the lab independently. FireAlive includes a regression test runner the lead CAN run inside the lab if they want, but FireAlive doesn't try to automate the entire change-management workflow — that varies too much across orgs.
+
+After the org's change-management approves the update, the lead pushes it to production from the same Updates tab. Production deployment includes rolling restart and a fuse counter increment to prevent rollback to a now-vulnerable version.
+
+**Workflow:**
+1. Update available — lead notified through configured channel
+2. Lead opens Updates tab
+3. Lead chooses destination: lab environment, alternate repository, or directly to production (rare; usually for emergency hotfixes)
+4. Update package is fetched and routed to the chosen destination
+5. (For lab destination) Org's developers run their own regression and security tests in the lab — possibly using FireAlive's built-in regression runner inside the lab, or their own tools
+6. Org's change management process approves or rejects the update independently
+7. After approval: lead returns to Updates tab and pushes the update from lab to production
+8. Production deployment: rolling restart, fuse counter increment, audit log entry
+
+### Troubleshooter
+**What it's for:** Interactive assistant that diagnoses why a feature isn't working. The lead describes the problem, the troubleshooter checks integrations, configs, logs, and suggests fixes.
+
+**Workflow:**
+1. Something's broken — "SOAR routing isn't assigning tickets"
+2. Lead opens Troubleshooter, types description
+3. System checks SOAR connectivity, routing engine status, recent audit logs
+4. Returns diagnosis + suggested fixes
+5. Lead either applies fix or escalates with the diagnosis as evidence
+
+---
+
+## Monitoring group
+
+### System Health
+**What it's for:** Aggregated runtime metrics across the server, MC, and all connected ACs. CPU, memory, heap, DB connections, request rates, error rates. Anomalies (sudden spikes, sustained high load) trigger SIEM/SOAR alerts.
+
+**Workflow:**
+1. Lead glances at System Health daily
+2. Spikes investigated immediately — could be load issue, could be attack
+3. SIEM gets the metric stream, dashboards integrate with broader SOC monitoring
+
+### Vulnerability Scan
+**What it's for:** Allow approved vulnerability scanners (Nessus, Qualys, etc.) to scan the FireAlive application. Only scanners from approved IP allowlist can connect; unauthorized scans are blocked at the network layer.
+
+**Workflow:**
+1. Lead opens Vulnerability Scan, adds approved scanner IPs
+2. Schedule a periodic scan
+3. Scanner runs, findings flow back through the org's vuln management process
+
+### Cloud Vulnerability Scan
+**What it's for:** Allow cloud-environment vulnerability scanners (ScoutSuite, Prowler, Pacu, CloudBrute, Checkov, Trivy) authorized access to scan FireAlive instances deployed in cloud environments. Catches misconfigurations specific to cloud deployment — exposed cloud storage, misconfigured IAM roles, network ACL gaps, container image vulnerabilities, virtual device exposure — that could be leveraged to compromise FireAlive or pivot to other resources.
+
+This is the cloud-specific companion to the Vulnerability Scan feature (which authorizes traditional vulnerability scanners) and to EDR/Threat Hunting (which authorize endpoint and behavioral scanners). Same model: FireAlive opens itself to authorized scanning by the org's security tooling.
+
+**Workflow:**
+1. Lead opens Cloud Vulnerability Scan
+2. Picks the scanners the org uses (one or more from the supported list)
+3. Configures the cloud environment FireAlive is deployed in (AWS / Azure / GCP / Hetzner / OVH / Exoscale)
+4. Schedules recurring scans (or runs ad-hoc)
+5. Scanners gain authorized access, run their checks against the FireAlive cloud deployment
+6. Findings come back in JSON/SARIF, displayed with severity and remediation guidance
+7. Lead remediates or assigns to platform team
+
+---
+
+## Audit group
+
+### Audit Log
+**What it's for:** Aggregated audit trail across MC + AC. Every meaningful action — logins, config changes, ticket assignments, peer flag resolutions, redemption approvals — gets a tamper-evident hash-chained entry. Searchable, paginated, exportable for forensics.
+
+**Workflow:**
+1. Auditor / lead investigation needs evidence
+2. Open Audit Log, filter by user / action type / time range / event type
+3. Find the entry, verify chain integrity, export
+
+---
+
+## Other MC tabs
+
+### Inbox
+**What it's for:** Optional storage for notifications the user wants to revisit. Per the Client Notifications design, notifications are delivered through the channels each user chose — email, SMS, desktop notification, inbox, multiple, or off. Inbox is one channel option. It's here for users who specifically want a place to find missed notifications; it's not the primary delivery mechanism.
+
+**Workflow:**
+1. User configures notification preferences (per type: email / SMS / desktop / inbox / multiple / off)
+2. Notifications fire to chosen channels
+3. If user includes inbox among channels, copies show up here
+4. User opens inbox occasionally to catch up on anything they missed live
+
+### Peer Conduct
+**What it's for:** Lead-side review of flags submitted by analysts after peer skill-share sessions or about Board posts. Tier 1 (minor — both anonymous, aggregate patterns only), Tier 2 (personal attack — flagged peer's identity revealed), Tier 3 (urgent — slurs/threats/harassment — both identities revealed, HR involvement warranted). Protects the peer support and Board space from being weaponized.
+
+**Workflow:**
+1. Analyst flags a peer session or a Board post as inappropriate
+2. Lead opens Peer Conduct → Open Flags
+3. Reviews flag tier and content
+4. For Tier 3: contacts HR with evidence
+5. For Tier 2: contacts flagged peer for conduct discussion
+6. For Tier 1: pattern analysis only — no individual action
+7. Lead resolves flag with note, audit log captures the resolution
+
+### Help (MC)
+**What it's for:** In-app help — this Feature Guide accessible by tab. Each tab in the MC has a corresponding mini-article in this Help menu.
+
+---
+
+# ANALYST CLIENT (the analyst's app)
+
+### Home
+**What it's for:** Analyst's daily landing. Shows their current burnout stage in big print, with optional context. Quick-action tiles for the four most common things they'd want to do (peer skill-share, delegate, training, self-scan) plus prominent buttons for "Request Reduced Tickets" and "Message Team Lead." Recent impact section showing positive reinforcement.
+
+The "Request Reduced Tickets" button is two-state: when reduced routing is OFF, the button activates it; when reduced routing is ON, the button turns it off. The analyst always has control over their own load reduction request.
+
+**Workflow:**
+1. Analyst logs in at start of shift
+2. Lands on Home — sees their current state, recent wins
+3. From here, navigates to whatever they need to do
+4. If they want load reduction: clicks Request Reduced Tickets → state toggles ON
+5. If they want to resume normal load: clicks the now-toggled button → state toggles OFF
+
+### My Signals
+**What it's for:** The analyst's own burnout signals. Investigation time, dismiss rate, ticket quality, escalation rate — all compared to the analyst's OWN baseline (not team comparisons). Click any signal for research-backed interventions. Privacy-critical: only the analyst sees this; the lead never does.
+
+**Workflow:**
+1. Analyst feels off, opens My Signals
+2. Sees: "Investigation time: 26 min vs your baseline of 20 min — that's 30% longer"
+3. Clicks the signal — gets context on what this typically means and research-backed responses
+4. Optionally requests reduced queue (anonymous) or messages lead (identified)
+
+### Inbox
+**What it's for:** Same as MC inbox — optional storage of notifications for users who chose inbox as a delivery channel.
+
+### Delegate
+**What it's for:** Send recurring ticket patterns to automated systems so analysts aren't doing repetitive work that doesn't need human judgment. Two cases:
+
+First, false positives — analysts close the same false alarm 10 times a day. The Delegate feature lets the analyst create a rule that sends those alerts straight to the SOAR or AI triage so the analyst stops seeing them.
+
+Second — and equally important — true positives that are nonetheless low-level repetitive work. Some real incident-response actions don't need human judgment: known-malware container quarantine, low-severity password resets, ticket enrichment, basic phishing categorization. If the org has automated systems registered (in the MC's Automation tab) capable of handling that kind of work, the analyst can delegate those tickets to those systems. The analyst gets back the time, the org gets the boring tickets handled. This is what the research on anti-burnout tooling actually shows works.
+
+**Workflow:**
+1. Analyst notices a pattern (either a recurring false positive or a real but boring repetitive task)
+2. Opens Delegate tab, clicks "+ New Delegation"
+3. Describes the pattern
+4. Picks target: SOAR auto-response, an AI triage system, or one of the automated systems the lead registered in MC's Automation tab
+5. Submits — lead approves the delegation in MC
+6. From now on, that pattern is auto-handled by the chosen system; analyst stops seeing it
+
+### Peers
+**What it's for:** Peer skill-share — E2EE chat between analysts to share knowledge, ask questions, learn techniques. NOT therapy or emotional support — that has separate channels. This is technical knowledge sharing. Anti-abuse flagging is built in. 4KB per message, auto-closes after inactivity, no persistence (chat ephemeral).
+
+**Workflow:**
+1. Analyst stuck on a technique — opens Peers
+2. Posts a skill-share request: "Anyone good with Splunk regex extraction?"
+3. Another analyst sees it, accepts, opens E2EE chat
+4. They work through the problem
+5. Session times out, chat is gone — but the helper earned points (Helper Pay)
+6. Either analyst can post-session flag if conduct was inappropriate
+
+### Board
+**What it's for:** Async forum for tips, questions, burnout strategies. Posts auto-expire after 7 days (so it's a current-conversation space, not a permanent record). Each post supports threaded responses so analysts can ask follow-up questions or add comments. The same conduct rules and tiered abuse flagging system from peer chat apply here too.
+
+If a post is flagged, it's temporarily removed from the Board pending Team Lead review. The flagged content is sealed in an evidence vault with no expiration (so it can't disappear before review). Both poster and flagger identities are revealed only to the lead during review. If the lead finds it doesn't violate org abuse policies, they dismiss the flag and the post returns to the Board. If the lead finds it does violate policies, a message pops up suggesting the lead escalate up the management/HR chain — same workflow as the peer chat tier system.
+
+**Workflow:**
+1. Analyst has a tip to share or a question with no time pressure
+2. Posts to Board with a category
+3. Other analysts read async and respond via threaded responses
+4. Posts age out after 7 days
+
+**Flagging workflow:**
+1. Analyst sees a post or response that's inappropriate
+2. Flags it with a tier (1: minor / 2: personal attack / 3: urgent — slurs, threats, harassment)
+3. Post is removed from Board pending review, stored in evidence vault
+4. Lead opens Peer Conduct in MC, reviews, dismisses or escalates
+
+### IR Simulator (this is the AI/ML training feature)
+**What it's for:** Train on YOUR organization's IR procedures — not generic textbook ones. Each scenario is generated from a real IR policy the lead uploaded. The analyst walks through OBSERVE → ORIENT → DECIDE → ACT phases, makes choices, gets feedback. Tracks IR Policy Mastery level over time. After completion, shows the actual policy that was used so the analyst can verify they're learning real org procedure.
+
+**Workflow:**
+1. Analyst opens IR Simulator at start of upskilling hour
+2. Sees their current Mastery level, which policies they've practiced
+3. Picks a policy they haven't done yet (or retries one to improve score)
+4. Walks through OODA phases with multi-choice decisions, gets feedback per choice
+5. Completes scenario — earns points, level may increase
+6. Sees the actual policy document used as the source for this scenario — confirms it matches their org's real procedure
+7. As more policies are uploaded by the lead, more scenarios become available
+
+### Skills & Assessments
+**What it's for:** Analyst's view of their own skill development. Sees assessments assigned by the lead. Sees baseline established from the AC's automatic baseline assessments at first-launch. Sees gap-driven training recommendations. When proficiency thresholds are crossed, the lead receives a growth signal — this is recognition, not a demand.
+
+**Workflow:**
+1. AC's first-launch baseline assessments establish initial skill profile (private to analyst)
+2. Lead later assigns a targeted assessment — analyst sees it here as an Assessment Required notification with a link to the external module
+3. Analyst goes to the external platform (HackTheBox/TryHackMe/etc.), takes the module
+4. Submits completion report (link, score, date) back through the AC
+5. Result populates gap display and training recommendations
+6. Lead also sees this targeted assessment's result (unlike baseline assessments which stay private)
+7. Gap areas auto-create training recommendations for that analyst
+8. When proficiency improves above threshold: growth signal sent to lead
+
+### Training & Certs
+**What it's for:** AI-recommended training based on assessment gaps. Categorized by skill area (SIEM Queries, Investigation, Escalation, Threat Hunting, Malware Analysis) with proficiency percentages and direct links to training platforms (TryHackMe, LetsDefend, HackTheBox, SANS, Cyberdefenders).
+
+When upskilling hour begins, ticket routing pauses for that analyst and a content filter activates on the AC's host machine — only training/peer chat/cert sites are accessible during that hour. The content filter uses the host operating system's native content-filter capability (FireAlive integrates with it rather than reimplementing it). Training URLs in this tab are copyable but not clickable: FireAlive deliberately does not call URLs to avoid exposing the suite to URL-based attacks. The analyst copies the URL into their browser themselves.
+
+**Workflow:**
+1. Analyst opens Training during upskilling hour
+2. Sees recommended modules by skill area, sorted by current proficiency
+3. Copies the module URL (not clickable — no FireAlive-initiated browsing)
+4. Pastes the URL into their browser, opens the training module
+5. Completes module on the platform
+6. Returns to FireAlive, submits completion (module name, platform, URL, date)
+7. Lead verifies completion, skill profile updates
+
+### Post-Incident Wellness
+**What it's for:** Personal wellness resources — always available, not just post-incident. Includes both built-in resources (breathing exercises, stress response education, self-care strategies) AND any wellness resources the lead has configured in the MC and propagated to the AC. So the org can add subsidized counseling services, EAP contact info, internal wellness programs, peer support channels, anything else specific to that org's employee wellbeing offerings.
+
+Tier-3 PRIVATE — the lead literally cannot see whether the analyst accesses these resources. Distinct from technical incident recovery procedures.
+
+**Workflow:**
+1. Analyst feels stressed (or just wants to maintain wellbeing)
+2. Opens Post-Incident Wellness
+3. Uses built-in breathing exercise widget, reads strategies
+4. Sees org-specific resources the lead provided (e.g. "Subsidized counseling: contact EAP at..." or "On-site wellness program: schedule at...")
+5. Accesses external mental health resources or org-provided support
+6. None of this is logged in a way the lead can see — fully private
+
+### Self-Scan
+**What it's for:** Analyst-initiated 10-point compromise check on their own client. Tests binary integrity, memory analysis, network connections, configuration drift, audit log continuity, TLS pinning, API tokens, filesystem integrity, EDR status, encryption keys. Results go to the analyst AND auto-send to MC — not optional, because client compromise affects the whole team.
+
+**Workflow:**
+1. Analyst notices something off about their machine, or it's part of weekly hygiene
+2. Opens Self-Scan, clicks Run
+3. Scan runs (~2-3 minutes), 10 checks
+4. Results display: pass/fail per check
+5. Auto-transmitted to MC — lead may follow up if any failed
+
+### Audit (AC-side)
+**What it's for:** Local audit log of events on this client. Auto-mirrored to MC. So if questions arise about what the analyst was doing at a specific time, they can see their own log.
+
+### Privacy
+**What it's for:** Analyst's data privacy controls and consent log. Shows what data is collected at Tier-1 (visible to lead, aggregate only) vs Tier-3 (private to analyst). Consent events log every privacy decision the analyst made.
+
+### Certifications
+**What it's for:** Where the analyst registers their professional industry certifications (CompTIA, ISACA, ISC², GIAC, etc.). Uploads cert file (PDF/image, encrypted), enters verification number. Lead verifies and the cert contributes to the analyst's skill profile.
+
+---
+
+# GLOBAL DASHBOARD (CISO read-only view)
+
+The GD aggregates anonymized data from multiple regional MCs. The CISO sees regional health, never individual analyst data. Read-only, separate server.
+
+### Global Overview
+Cross-region aggregate health.
+
+### Regional Breakdown
+Per-region health bars, automation rates, cert coverage.
+
+### Reports
+Generate executive reports for board presentations.
+
+### MC Connections
+Manage which MCs feed data here. Add/remove regional MCs.
+
+### MC Offboarding
+When a regional SOC is decommissioned, offboard its MC. Historical data retention per policy.
+
+### CISO Notifications
+Threshold alerts when any region crosses critical lines (burnout health below threshold, SLA below %, turnover risk high).
+
+### Query Tool
+Run cross-region queries: burnout trends, turnover risk, cert gaps, automation ROI.
+
+### System Health
+Self-monitoring of the GD server.
+
+### Monitoring Integrations
+Connect GD to org's monitoring stack so compromise of the GD itself is detected.
+
+### IAM & Access / MFA / Posture / WiFi / Compromise Scan / Vulnerability Scan / Regression Test / Cloud & IaC / SDN-SASE / HA & Clustering / Backup / Data Sovereignty / Recertification / Troubleshooter / App Updates
+Same purposes as MC equivalents but scoped to the GD server (which is independent infrastructure separate from the regional MC).
+
+### Audit & Forensics
+Audit trail visibility for the GD layer — separate audit log from the regional MCs.
+


### PR DESCRIPTION
Plain-language reference describing every feature in the FireAlive suite. For each feature: what it's for, who uses it, when, and the workflow to use it.

Covers all three apps: Management Console (lead-side), Analyst Client (analyst-side), and Global Dashboard (CISO-side).

Two intended uses:

  - Source of truth for what each feature is supposed to do. Implementations get fixed to match this guide; the guide doesn't get bent to match what's currently coded.

  - Bundled in every FireAlive distribution and surfaced as in-app Help articles. Each tab in MC/AC/GD has a corresponding mini-article in this guide that the Help tab will display. Help integration is planned in a future phase.

This guide also documents two features that have been discontinued (UTM integration, Elasticity) and several features that need behavior corrections in upcoming releases (notification delivery channels, feature toggle greying behavior, Board threading and flagging, Restore compromise-recovery workflow, Report Engine and Compliance PDF/DOCX generation, Training URL handling, Post-Incident Wellness lead-configured resources, AC Home two-state Reduced Tickets toggle, MC Certifications direct input wizard, Updates simplified destination picker).

The runbook generator entry reflects the corrected purpose: FireAlive-specific failure and compromise scenarios, not generic incident response. The v1.0.12 implementation is misaligned with this purpose and will be reverted in the next release per the build plan.