### PR TITLE
Hotfix: enforce JWT verification in websocket auth handler

### DIFF
--- a/server/services/websocket-server.js
+++ b/server/services/websocket-server.js
@@ -36,11 +36,29 @@ class FireAliveWebSocket {
   _handleMessage(ws, msg) {
     switch (msg.type) {
       case 'auth':
-        // Validate JWT token
-        ws.userId = msg.userId;
-        this.clients.set(msg.userId, ws);
-        this._updateHeartbeat(msg.userId, true);
-        this._send(ws, { type: 'auth_ok' });
+        // JWT verification — reject connections that don't present a
+        // valid, non-expired token. The client-supplied msg.userId
+        // is intentionally ignored; ws.userId is set from the verified
+        // token payload so a spoofed userId cannot be substituted.
+        if (!msg.token || typeof msg.token !== 'string') {
+          this._send(ws, { type: 'auth_error', error: 'Token required' });
+          ws.close(1008, 'auth required');
+          return;
+        }
+        try {
+          const { verifyToken } = require('../middleware/auth');
+          const decoded = verifyToken(msg.token);
+          ws.userId = decoded.id;
+          ws.userRole = decoded.role;
+          this.clients.set(decoded.id, ws);
+          this._updateHeartbeat(decoded.id, true);
+          this._send(ws, { type: 'auth_ok', userId: decoded.id });
+        } catch (err) {
+          const code = err.name === 'TokenExpiredError' ? 'TOKEN_EXPIRED' : 'INVALID_TOKEN';
+          this._send(ws, { type: 'auth_error', error: err.message, code });
+          ws.close(1008, 'auth failed');
+          return;
+        }
         break;
       case 'heartbeat':
         ws.isAlive = true;


### PR DESCRIPTION
Fixes a security vulnerability in services/websocket-server.js where the 'auth' message handler trusted the client-supplied msg.userId without verifying any token. Any websocket client could send {type: 'auth', userId: '<any user id>'} and be accepted as that user — including roles like 'lead' or 'admin'.

The vulnerability affected every downstream websocket feature that gates on ws.userId: realtime peer-chat presence (the E2EE peer messages route through `peer_message` events keyed on ws.userId), inbox push notifications, signal-reading writes into the AI burnout engine, and the routing/notification subscription channels. The peer-chat privacy claims in particular depend on ws.userId being trustworthy.

The original handler had a comment "Validate JWT token" but no validation code — the comment described intent, not behavior.

Changed:

  - The 'auth' case now requires msg.token (a JWT) and rejects connections that don't present one. The token is verified via verifyToken() from middleware/auth.js — the same verifier the HTTP middleware uses, so the algorithm (HS256), secret (JWT_SECRET env var), and expiry semantics are consistent across transports.

  - ws.userId is now set from decoded.id (the verified token payload), never from msg.userId. The msg.userId field is intentionally ignored so a spoofed value cannot substitute for the verified identity.
  - ws.userRole is also captured from the token for any future role-gated websocket features.

  - On verification failure, the handler sends a typed auth_error message back to the client (with code 'TOKEN_EXPIRED' or 'INVALID_TOKEN' to mirror the HTTP middleware) and closes the connection with WebSocket close code 1008 (policy violation). Closing prevents brute-force token guessing on a single connection.

Kept (intentionally):

  - The verifyToken function itself in middleware/auth.js. Same verifier, used from both HTTP and WS — single source of truth for what counts as a valid session.

  - All other case handlers (heartbeat, peer_message, signal_reading, subscribe_routing, subscribe_notifications) unchanged. They already gate on ws.userId being non-null, which only happens after successful verified auth in the new code path. No new gating needed.

  - The lazy-require pattern. verifyToken is required inside the auth case (matching the file's existing pattern for SignalCollector, AiBurnoutEngine, SiemAdapter).

Client-side impact: existing websocket clients that send {type: 'auth', userId: ...} will be rejected after this fix. The MC and AC websocket bootstrap code needs to be updated to include msg.token (the access JWT they already hold for HTTP calls) when sending the auth message. That client-side update is being tracked but does not block this server-side hardening — a broken websocket auth handshake is a much smaller harm than the spoofing it prevents.

Bundled into v1.0.17 with Phase F4b. Not separately tagged since v1.0.16 is currently a pre-release on the public Releases page and the exposure window is narrow.