### PR TITLE
Hotfix: align retention purge whitelist with purge call sites

### DIFF
--- a/server/services/retention.js
+++ b/server/services/retention.js
@@ -42,7 +42,23 @@ function runRetentionPurge() {
       if (days <= 0 && label !== 'peer_messages') return;
       const cutoff = new Date(Date.now() - (days || 1) * 86400000).toISOString();
       // SECURITY: Whitelist table/column names to prevent SQL injection
-      const SAFE_TABLES = {'signal_readings':'recorded_at','audit_log':'timestamp','notifications':'created_at','backup_history':'created_at','peer_sessions':'created_at'};
+      // Whitelist of (table, date_column) pairs that the retention
+      // purge is allowed to operate on. Every table targeted by a
+      // purge() call below MUST be in this map with its correct
+      // date column, or the purge will throw 'Invalid table' and
+      // abort the entire purge cycle.
+      const SAFE_TABLES = {
+        'analyst_signals': 'recorded_at',
+        'audit_log': 'timestamp',
+        'sla_measurements': 'measured_at',
+        'peer_messages': 'created_at',
+        'reports': 'generated_at',
+        'analyst_consent_log': 'created_at',
+        'sessions': 'expires_at',
+        'signal_readings': 'recorded_at',
+        'notifications': 'created_at',
+        'peer_sessions': 'created_at',
+      };
       if (!SAFE_TABLES[table] || SAFE_TABLES[table] !== dateCol) throw new Error('Invalid table');
       const r = db.prepare(`DELETE FROM ${table} WHERE ${dateCol} < ?`).run(cutoff);
       results[label] = r.changes;


### PR DESCRIPTION
Fixes a correctness bug in services/retention.js where the SAFE_TABLES whitelist did not match the tables that runRetentionPurge() actually targets. Six of the seven purge calls in the function body referenced tables not in the whitelist, so they threw 'Invalid table' at runtime. Worse, the throw on the second purge call (analyst_signals) caused the surrounding try/catch to abort the entire purge cycle — in production only audit_log was ever being purged, and the six other tables grew unbounded.

The bug was silent. The error was caught, logged, and swallowed; the daily 04:00 retention scheduler reported success on every cycle while six retention policies were not being enforced.

Tables affected (now retained beyond their configured TTL until backfill runs):

  - analyst_signals (signal_readings is the v1.0.0 name; this is the canonical table) — burnout signal time series. 90- day default retention. Heavy growth driver in long-running deployments since signals are written every 15 minutes per analyst by the websocket service. Affects database size and query performance.

  - sla_measurements — SLA tracking time series. 180-day default retention.

  - peer_messages — encrypted peer-chat messages. Should be deleted on session close, but the purge() call existed to clean up stragglers. With purge broken, any session that didn't close cleanly leaves messages in the table indefinitely. Privacy-relevant.

  - reports — generated compliance/audit reports. 365-day default retention.

  - analyst_consent_log — peer-chat identity-reveal consent records. 365-day default retention.

  - sessions — expired JWT refresh sessions. 30-day default retention. Should be cleaned up regularly because the table is queried on every refresh-token endpoint hit.

The fix replaces the whitelist with one that includes all seven tables that purge() targets, plus three additional real tables (signal_readings, notifications, peer_sessions) that exist in the schema and may be added to the purge cycle in a future commit. Each entry maps the table name to its authoritative date column as defined in db/init.js.

Removed:

  - 'backup_history' — the table does not exist anywhere in the schema. Stale entry from earlier code.

Kept (intentionally):

  - The whitelist guard mechanism itself. Whitelist-based table/column validation prevents SQL injection through the dynamic table-name substitution in the DELETE statement. The fix expands the whitelist; it does not weaken the guard.

  - Multi-line dict format (one entry per line) instead of the previous single-line inline object. Audit-trail readability matters more than line count for security- relevant code.

  - All purge() call sites unchanged. The bug was in the whitelist, not in the call sites.

  - The try/catch/finally structure. Error handling stays the same; the difference is that the underlying error no longer fires for legitimate tables.

After this fix, the next 04:00 scheduler run will execute all seven purges. Deployments that have been running for a while may see a one-time large delete on tables that have been growing unbounded — particularly analyst_signals. That's the correct behavior; just expect the first run post-fix to take longer than steady-state.

Bundled into v1.0.17 with Phase F4b. Not separately tagged since v1.0.16 is currently a pre-release on the public Releases page.