### PR TITLE
Hotfix: populate db handle for websocket server

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -17,7 +17,7 @@ const cors = require('cors');
 const compression = require('compression');
 const rateLimit = require('express-rate-limit');
 const path = require('path');
-const { initDb } = require('./db/init');
+const { initDb, getDb } = require('./db/init');
 const { logger } = require('./services/logger');
 const { auditMiddleware } = require('./middleware/audit');
 const { authMiddleware } = require('./middleware/auth');
@@ -205,7 +205,7 @@ async function start() {
 
     // Initialize WebSocket server for real-time features
     try {
-      const wsServer = new FireAliveWebSocket(server, app.locals?.db);
+      const wsServer = new FireAliveWebSocket(server, getDb());
       wsServer.startHeartbeatCheck();
       logger.info('WebSocket server started on /ws');
       process.on('SIGTERM', () => { wsServer.shutdown(); server.close(); });


### PR DESCRIPTION
Fixes a latent bug introduced before v1.0.16 where the WebSocket server received undefined as its database handle and silently failed every database query at runtime.

server/services/websocket-server.js stores the constructor's db argument as this.db and uses it in 7 places: signal recording, heartbeat updates, signal collection (15-minute interval), SIEM push (60-second interval), routing feed broadcasts, notification dispatch, and metrics collection. Each call would have thrown TypeError: Cannot read property 'prepare' of undefined.

These failures didn't surface because the WebSocket connection's message handler wraps each call in try/catch and the periodic intervals have their own internal try/catch. The errors were caught, swallowed, and never logged anywhere visible. The result was that real-time features (signal recording from analyst clients, peer-chat presence updates, inbox push notifications, periodic SIEM push, routing feed) all silently no-op'd in production.

The bug was that line 208 read app.locals?.db, which was never set anywhere in the codebase. The aspirational pattern was there but the populating side of the contract was missing.

Changed:

  - Line 20 — import getDb alongside initDb from server/db/init. The init module already exports both; we just weren't using getDb here.

  - Line 208 — pass getDb() instead of app.locals?.db to FireAliveWebSocket's constructor. The handle is created once at server startup and lives for the lifetime of the process, which matches the websocket server's usage pattern (long-lived intervals plus per-message operations on a shared handle).

Why a long-lived handle here vs. the per-call pattern used in routes:

  - WebSocket server has periodic intervals (15-minute signal collection, 60-second SIEM push). Per-interval open/close churn would be wasteful.
  - better-sqlite3 with WAL mode (set in getDb) supports concurrent reads from multiple connections without blocking, so a long-lived handle on the websocket side doesn't contend with the per-request handles in routes.
  - The existing constructor signature already takes a db, not a getDb function, so this change is the minimal edit that restores the intended behavior.

Kept (intentionally):

  - The per-call getDb()/db.close() pattern in routes and services. That pattern is correct for short-lived request handlers; only the websocket server has the long-lived-process profile that justifies a persistent handle.

  - The constructor signature in websocket-server.js — constructor(server, db). Backward-compatible.

  - app.locals — left unset because nothing else in the codebase reads it. The half-implemented contract is fully retired in favor of the explicit getDb() call.

  - The try/catch wrapping in the websocket message handler and intervals. It's not wrong defense — websockets legitimately need to swallow errors so a single bad message doesn't tear down the connection — it just happened to mask this specific bug. With db now valid, the catch blocks will return to catching only real runtime errors.

User-visible impact after this fix lands:

  - Analyst signal recordings via websocket will actually persist (previously: appeared to record in the UI, silently dropped server-side)
  - Peer chat presence indicators will update from the server's authoritative state
  - SIEM push will resume sending metrics every 60 seconds
  - Inbox notifications dispatched over websocket will actually fan out

Bundled into v1.0.18 with Phase F4c. Not separately tagged since v1.0.17 is currently a pre-release on the public Releases page and the affected paths fail-soft.