### PR TITLE
Hotfix: correct backend services count in README (23 -> 37)

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Five components:
 | **Global Dashboard (GD)** | Electron + React | CISO cross-region oversight |
 | **GD Server** | Node.js + Express + SQLite | Aggregates data from regional servers |
 
-### Backend Services (23 files)
+### Backend Services (37 files)
 
 | Service | Purpose |
 |---------|---------|


### PR DESCRIPTION
Fixes a long-standing documentation drift in README.md. The Backend Services section heading claims "23 files" but the actual count in server/services/ is 37 as of v1.0.17.

The drift accumulated across multiple releases:
  - F4a (v1.0.16) added 3 services: ai-provider, internal-llm, external-llm
  - F4b (v1.0.17) added 3 more: ir-policy-parser, ooda-scenario-generator, content-sanitizer
  - The "23" number was already inaccurate before F4a; the count was last reconciled when the codebase had significantly fewer services and was never updated as services accumulated through pre-1.0 phases.

Documentation drift is a credibility issue for a security- claiming product. A user reading the README to understand what's running on their network needs the count to be correct.

Changed:

  - Line 28 — "Backend Services (23 files)" replaced with "Backend Services (37 files)" reflecting the actual count returned by `ls server/services/*.js | wc -l` against the v1.0.17 source tree.

Kept (intentionally):

  - The 10-row illustrative table below the heading. The table was never intended to be exhaustive — it shows the user-facing high-impact services. Listing all 37 would bloat the README and most are internal infrastructure (logger, scheduler, encryption, etc.) that aren't useful for a high-level overview. The illustrative-vs-exhaustive distinction is acceptable; the count claim is what needed correcting.

  - All other documentation. No other counts or claims changed.

  - The Security Middleware count "9 modules, 877 lines" on line 43 — verified accurate against the actual middleware/ directory; not touched here.

Bundled into v1.0.18 with Phase F4c. Not separately tagged.