### PR TITLE
Add sub-package version sync automation (no version bump)

### DIFF
--- a/.github/workflows/sync-versions.yml
+++ b/.github/workflows/sync-versions.yml
@@ -1,0 +1,50 @@
+# Sync sub-package package.json versions with the root package.json on every
+# branch push (except main and tag pushes). If scripts/sync-versions.js
+# updates any sub-package.json files, this workflow auto-commits the changes
+# back to the same branch.
+#
+# The root package.json is the source of truth for the project version;
+# electron-builder reads each sub-package's package.json at build time to
+# stamp the installer, so the version fields must match. This workflow keeps
+# them in sync without requiring the contributor to manually edit four files
+# on every version bump.
+#
+# Pushes made with the default GITHUB_TOKEN do not trigger downstream
+# workflow runs, so the auto-commit does not re-trigger this workflow.
+
+name: Sync sub-package versions
+
+on:
+  push:
+    branches:
+      - '**'
+      - '!main'
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: '22'
+
+      - name: Run sync script
+        run: node scripts/sync-versions.js
+
+      - name: Commit changes if any
+        run: |
+          if git diff --quiet; then
+            echo "No changes; nothing to commit."
+          else
+            git config user.name "github-actions[bot]"
+            git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+            git add frontend/package.json packages/analyst-client/package.json packages/global-dashboard/package.json
+            git commit -m "chore: auto-sync sub-package versions to match root"
+            git push
+          fi

--- a/scripts/sync-versions.js
+++ b/scripts/sync-versions.js
@@ -1,0 +1,105 @@
+#!/usr/bin/env node
+// ═══════════════════════════════════════════════════════════════════════════════
+// FIREALIVE — Sub-package version sync script
+// Copyright (C) 2026 Peter Mancina
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// ═══════════════════════════════════════════════════════════════════════════════
+//
+// Reads the version field from the root package.json and writes it into each
+// sub-package's package.json where the version differs. Preserves all other
+// formatting in the target files by doing a targeted regex replacement on the
+// version field rather than a JSON parse + re-stringify, which would lose
+// hand-authored indentation, key order, or trailing newlines.
+//
+// Run by .github/workflows/sync-versions.yml on every branch push (except
+// pushes to main and tag pushes). The workflow auto-commits any changes back
+// to the same branch, so a contributor only needs to edit the root package.json
+// when bumping a project version.
+//
+// Run manually: `node scripts/sync-versions.js`
+//
+// Exit codes:
+//   0 — sync completed (with or without changes)
+//   1 — root package.json missing or has no version field
+//
+// The packages/global-dashboard-server sub-package is intentionally NOT in
+// the sync list. It is an independent component with its own version string
+// and lifecycle.
+// ═══════════════════════════════════════════════════════════════════════════════
+
+const fs = require('fs');
+const path = require('path');
+
+const ROOT = path.resolve(__dirname, '..');
+const ROOT_PKG = path.join(ROOT, 'package.json');
+
+const SUB_PACKAGES = [
+  'frontend/package.json',
+  'packages/analyst-client/package.json',
+  'packages/global-dashboard/package.json',
+];
+
+function getRootVersion() {
+  if (!fs.existsSync(ROOT_PKG)) {
+    console.error('Error: root package.json not found at ' + ROOT_PKG);
+    process.exit(1);
+  }
+  const root = JSON.parse(fs.readFileSync(ROOT_PKG, 'utf8'));
+  if (!root.version) {
+    console.error('Error: root package.json has no version field');
+    process.exit(1);
+  }
+  return root.version;
+}
+
+// Read just the version field from a package.json without parsing the full
+// file. Used so other formatting differences (whitespace, key order, trailing
+// newline) do not get reported as a version change.
+function readVersionField(content) {
+  const m = content.match(/"version"\s*:\s*"([^"]+)"/);
+  return m ? m[1] : null;
+}
+
+// Replace the first version field's value with the given version. Preserves
+// the original spacing inside the field declaration and leaves all other
+// content untouched.
+function setVersionField(content, newVersion) {
+  return content.replace(
+    /("version"\s*:\s*")([^"]*)(")/,
+    (match, p1, _oldVersion, p3) => p1 + newVersion + p3
+  );
+}
+
+function main() {
+  const rootVersion = getRootVersion();
+  console.log('Root package.json version: ' + rootVersion);
+
+  let changed = 0;
+  for (const rel of SUB_PACKAGES) {
+    const abs = path.join(ROOT, rel);
+    if (!fs.existsSync(abs)) {
+      console.warn('[skip] ' + rel + ' not found');
+      continue;
+    }
+    const oldContent = fs.readFileSync(abs, 'utf8');
+    const oldVersion = readVersionField(oldContent);
+    if (oldVersion === null) {
+      console.warn('[skip] ' + rel + ' has no version field');
+      continue;
+    }
+    if (oldVersion === rootVersion) {
+      console.log('[ok]   ' + rel + ' already at ' + rootVersion);
+      continue;
+    }
+    const newContent = setVersionField(oldContent, rootVersion);
+    fs.writeFileSync(abs, newContent);
+    console.log('[upd]  ' + rel + ': ' + oldVersion + ' -> ' + rootVersion);
+    changed++;
+  }
+
+  console.log('');
+  console.log('Done. ' + changed + ' file(s) updated.');
+  process.exit(0);
+}
+
+main();


### PR DESCRIPTION
Adds a small Node script and a GitHub Actions workflow that together
keep sub-package.json version fields in sync with the root package.json
automatically on every branch push. After this PR ships, a project
version bump touches only the root package.json and the README — the
three sub-package.json files (frontend, analyst-client, global-
dashboard) are updated automatically and committed back to the PR
branch by the workflow.

This PR carries no version bump of its own. The workflow exercises
itself on the push of commit 2 as a clean no-op against the v1.0.21
baseline (everything is already in sync), and starts producing real
auto-commits on the next root version bump.

## What's in the PR

1. `scripts/sync-versions.js` — Node script that reads the root
   package.json version and writes it into each sub-package's
   package.json where the version differs. Preserves all other
   formatting in the target files by doing a targeted regex
   replacement on the version field rather than a JSON parse +
   re-stringify (which would lose hand-authored indentation, key
   order, and trailing newlines). Idempotent — re-running on an
   already-synced tree is a no-op. Exits 0 with or without changes;
   exits 1 only on a missing or invalid root package.json.

2. `.github/workflows/sync-versions.yml` — GitHub Actions workflow
   that runs the script on every branch push (except pushes to main
   and tag pushes) and on manual dispatch. If the script updates
   any sub-package.json files, the workflow commits the changes
   back to the same branch as `github-actions[bot]` with the
   subject `chore: auto-sync sub-package versions to match root`.

## Sync targets

```
frontend/package.json
packages/analyst-client/package.json
packages/global-dashboard/package.json
```

`packages/global-dashboard-server` is intentionally NOT in the sync
list. It is an independent component with its own version string and
its own lifecycle.

## Why this design

- **Regex over JSON parse/re-stringify:** the JS standard library's
  `JSON.stringify` cannot reproduce arbitrary input formatting. A
  parse-then-stringify round-trip would lose key order, indentation
  width, and trailing newlines, producing a noisy diff for every
  run. The regex touches only the version field's value and leaves
  everything else byte-identical.

- **Trigger excludes main:** pushes to main should already be in
  sync because the workflow ran on the PR branch before the merge.
  Running on main would either be a redundant no-op or risk an
  auto-commit chain on the main branch.

- **No infinite loop concern:** pushes made with the default
  GITHUB_TOKEN do not trigger downstream workflow runs (documented
  Actions behavior). So the auto-commit step does not re-queue this
  workflow.

- **Action and Node versions match build.yml:**
  `actions/checkout@v6`, `actions/setup-node@v6`, `node-version: '22'`.

## New contributor workflow for version bumps

Before:
1. Edit root `package.json` (version + fuseCounter + buildId)
2. Edit `README.md`
3. Edit `frontend/package.json`
4. Edit `packages/analyst-client/package.json`
5. Edit `packages/global-dashboard/package.json`

After:
1. Edit root `package.json` (version + fuseCounter + buildId)
2. Edit `README.md`
3. Push — the workflow auto-commits the three sub-package.json
   updates back to the branch.

## Out of scope

- Anything that touches the runtime app behavior. This is pure
  build-time tooling.
- Verification that the workflow actually fires the auto-commit
  path. The first observable run is a no-op (everything's already
  in sync at v1.0.21). The auto-commit path will be exercised on
  the next root version bump in the next feature PR.
