### PR TITLE
fix(electron): replace removed new-window event with setWindowOpenHandler across all three Electron apps

### DIFF
--- a/frontend/main.js
+++ b/frontend/main.js
@@ -6,7 +6,7 @@ let serverProcess = null;
 
 app.on('web-contents-created', (event, contents) => {
   contents.on('will-navigate', (e) => e.preventDefault());
-  contents.on('new-window', (e) => e.preventDefault());
+  contents.setWindowOpenHandler(() => ({ action: 'deny' }));
 });
 
 function startServer() {

--- a/packages/analyst-client/main.js
+++ b/packages/analyst-client/main.js
@@ -5,7 +5,7 @@ const path = require('path');
 // Security: disable navigation to external URLs
 app.on('web-contents-created', (event, contents) => {
   contents.on('will-navigate', (e) => e.preventDefault());
-  contents.on('new-window', (e) => e.preventDefault());
+  contents.setWindowOpenHandler(() => ({ action: 'deny' }));
 });
 
 function createWindow() {

--- a/packages/global-dashboard/main.js
+++ b/packages/global-dashboard/main.js
@@ -6,7 +6,7 @@ let gdServerProcess = null;
 
 app.on('web-contents-created', (event, contents) => {
   contents.on('will-navigate', (e) => e.preventDefault());
-  contents.on('new-window', (e) => e.preventDefault());
+  contents.setWindowOpenHandler(() => ({ action: 'deny' }));
 });
 
 function startGdServer() {


### PR DESCRIPTION
## Summary

The deprecated `new-window` webContents event was [removed in Electron 22](https://github.com/electron/electron/pull/34526). FireAlive's three Electron apps (analyst-client, global-dashboard, frontend) have been calling `contents.on('new-window', (e) => e.preventDefault())` since well before the 22 → 41 upgrade range, which has been a silent no-op throughout. This PR replaces all three call sites with `webContents.setWindowOpenHandler()`, the modern replacement available since Electron 12.

Surfaced during pre-merge review of the Electron 41 → 42 dependabot bump (PR #112).

## Security significance

Without this fix:
- ✅ `will-navigate` was still blocking within-window navigation (works fine)
- ❌ Any `window.open()` or `target="_blank"` link in the renderer was NOT being blocked

After this fix:
- ✅ `will-navigate` continues to block within-window navigation
- ✅ `setWindowOpenHandler(() => ({ action: 'deny' }))` denies ALL window.open() requests unconditionally

For a SOC platform with CISO-tier oversight, closing the `window.open()` exposure matters. Combined with the existing CSP (`frame-src 'none'`), contextIsolation, sandbox, and `webSecurity: true`, the renderer's navigation-based exfiltration surface is now properly closed at the Electron layer.

## Changes

Three commits, one per Electron app, all identical in intent:

- `fix(electron/analyst-client): replace removed new-window event with setWindowOpenHandler`
- `fix(electron/global-dashboard): replace removed new-window event with setWindowOpenHandler`
- `fix(electron/frontend): replace removed new-window event with setWindowOpenHandler`

Each commit changes the same 3-line block in its respective main.js, replacing the no-op `new-window` listener with a `setWindowOpenHandler` denying all window-open requests.

## Verification

No test changes needed — the original handler was a no-op, so no test was depending on its behavior. The new handler enforces the documented Electron 12+ pattern.

After merging the Electron 41 → 42 bump (PR #112) and this PR, the next time a developer runs `npm run start` in any of the three apps, `setWindowOpenHandler` will be the active mechanism. No deprecation warnings will appear in the console.