### PR TITLE
chore(docker): bump base image from node:20-alpine to node:24-alpine

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:20-alpine AS builder
+FROM node:24-alpine AS builder
 WORKDIR /app
 RUN addgroup -g 1001 firealive && adduser -u 1001 -G firealive -s /bin/sh -D firealive
 COPY package.json ./
@@ -6,7 +6,7 @@ RUN npm ci --production && npm cache clean --force
 COPY server/ ./server/
 COPY .env.example .env
 RUN find server/ -name "*.js" -exec sha256sum {} \; > /app/integrity-manifest.sha256
-FROM node:20-alpine
+FROM node:24-alpine
 WORKDIR /app
 RUN addgroup -g 1001 firealive && adduser -u 1001 -G firealive -s /bin/sh -D firealive
 COPY --from=builder /app /app


### PR DESCRIPTION
Bumps the Dockerfile base image on both build stages (builder + runtime) from node:20-alpine to node:24-alpine.

Why now

Node.js 20 reached End-of-Life on April 30, 2026 — five weeks ago. EOL means upstream stops shipping security patches; the official Docker Hub image stops gaining updates; and library maintainers begin dropping prebuilt binaries for it. The forcing function on FireAlive's side is Dependabot PR #124 (better-sqlite3 12.9.0 → 12.10.0), which drops Node 20 prebuilds entirely. With #124 merged on a Node-20 Dockerfile, npm ci would fall through to source compilation and fail because Alpine doesn't ship build tooling.

Why Node 24 (not 22)

Two-year LTS schedule alignment as of May 2026:
  - Node 24 — Active LTS since October 2025, Active until October 2026, then Maintenance until April 2028
  - Node 22 — Maintenance LTS since October 2025, ends April 2027
  - Node 20 — EOL April 2026 (just passed)

Node 24 provides the longest support tail (~22 months runway), is the recommended target for new code by the Node.js working group, and is the version better-sqlite3 12.10.0 ships prebuilds for alongside 22 and 26.

Compatibility check across FireAlive's native modules

  - better-sqlite3 ^12.9.0     prebuild available for Node 24 (and 22, 26)
  - sharp ^0.34.5              Node 24 supported since 0.33.4
  - bcryptjs ^3.0.3            pure JS, no native binding
  - tweetnacl + tweetnacl-util pure JS, no native binding

No other code-level changes required: no engines field is declared in any package.json, no .nvmrc or .node-version file exists, the GitHub Actions build.yml already uses node-version 22 for installer builds (independent of the Dockerfile).

What ships in this commit

  Dockerfile line 1: FROM node:20-alpine AS builder -> FROM node:24-alpine AS builder
  Dockerfile line 9: FROM node:20-alpine            -> FROM node:24-alpine

No other lines change. Both stages remain alpine variants (consistent with the existing image-size posture). The runtime stage still runs as the unprivileged firealive user, still exposes 3001, still uses the same HEALTHCHECK / CMD / ENV declarations.

Validation
  - Verified across the working tree: only Dockerfile references node:20 (grep confirmed)
  - docker-compose.yml builds from this Dockerfile via build: . (no separate image pin to update)
  - GitHub Actions build.yml already uses node-version: '22' (independent of the Dockerfile)
  - Both FROM statements use the same major; no multi-major skew between builder + runtime

What this unblocks

Once this lands on main, Dependabot PR #124 (better-sqlite3 12.10.0) can be rebased and merged safely — Node 24 has full prebuild coverage in 12.10.0. The remaining Dependabot PRs (#122 @aws-sdk/client-s3, #123 express-rate-limit, #125 ws — already merged) are pure-JS bumps unaffected by the Node version.

Out of scope

  - No application code changes
  - No package.json engines field added (deferred — operator preference)
  - No version bump for FireAlive itself (R3l release ceremony parks until all R3l work is done)
  - global-dashboard-server's own Dockerfile is not affected (it doesn't have one in this tree)