### PR TITLE
R3l release ceremony: v1.0.38 (fuseCounter 31, buildId 20260520.1)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # FireAlive — SOC Analyst Wellbeing Platform
 
-**Version:** v1.0.37 | **License:** AGPL-3.0-or-later | **Author:** Peter Mancina   
-**E-fuse counter:** 30 (anti-rollback)
+**Version:** v1.0.38 | **License:** AGPL-3.0-or-later | **Author:** Peter Mancina   
+**E-fuse counter:** 31 (anti-rollback)
 
 ---
 
@@ -21,7 +21,7 @@ The name plays on the notion of burnout — FireAlive keeps the fire burning lon
 
 > **⚠️ Pre-Release Notice:** FireAlive is in pre-release. It should be evaluated in a lab or sandbox environment before any production deployment. SOC teams should thoroughly test all integrations, routing logic, and security controls in a non-production setting before relying on FireAlive for operational use. Community testing, feedback, and contributions are welcome.
 
-**Download installers:** Pre-built installers for Mac (.dmg), Windows (.exe), and Linux (.AppImage) are available on the [Releases page](https://github.com/petermancina/firealive/releases/tag/v1.0.37) under Tags.
+**Download installers:** Pre-built installers for Mac (.dmg), Windows (.exe), and Linux (.AppImage) are available on the [Releases page](https://github.com/petermancina/firealive/releases/tag/v1.0.38) under Tags.
 
 See **SETUP.md** for detailed setup instructions, and **FEATURE-GUIDE.md** for what each feature does and how to use it.
 

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "firealive-management-console",
-  "version": "1.0.37",
+  "version": "1.0.38",
   "description": "FireAlive \u2014 Management Console",
   "main": "main.js",
   "author": "Peter Mancina",

--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
   "name": "firealive",
-  "version": "1.0.37",
-  "fuseCounter": 30,
-  "buildId": "20260517.1",
+  "version": "1.0.38",
+  "fuseCounter": 31,
+  "buildId": "20260518.1",
   "description": "FireAlive — SOC Analyst Wellbeing Platform. Burnout-aware ticket routing, peer skill-share, post-incident wellness, skills assessments, and team health monitoring with privacy-first architecture.",
   "main": "server/index.js",
   "directories": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "firealive",
   "version": "1.0.38",
   "fuseCounter": 31,
-  "buildId": "20260518.1",
+  "buildId": "20260520.1",
   "description": "FireAlive — SOC Analyst Wellbeing Platform. Burnout-aware ticket routing, peer skill-share, post-incident wellness, skills assessments, and team health monitoring with privacy-first architecture.",
   "main": "server/index.js",
   "directories": {

--- a/packages/analyst-client/package.json
+++ b/packages/analyst-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "firealive-analyst-client",
-  "version": "1.0.37",
+  "version": "1.0.38",
   "description": "FireAlive SOC Analyst Wellbeing Platform \u2014 Analyst Client",
   "main": "main.js",
   "author": "Peter Mancina",

--- a/packages/global-dashboard-server/package.json
+++ b/packages/global-dashboard-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "firealive-global-dashboard-server",
-  "version": "1.0.37",
+  "version": "1.0.38",
   "description": "FireAlive Global Dashboard — Independent Backend Server",
   "main": "index.js",
   "scripts": {

--- a/packages/global-dashboard/package.json
+++ b/packages/global-dashboard/package.json
@@ -1,6 +1,6 @@
 {
   "name": "firealive-global-dashboard",
-  "version": "1.0.37",
+  "version": "1.0.38",
   "description": "FireAlive \u2014 Global CISO Dashboard",
   "main": "main.js",
   "author": "Peter Mancina",


### PR DESCRIPTION
Closes out R3l. Six logical commits bumping version + anti-rollback + build-identity across all 5 package.json files plus the README header trio + Releases-page link.

## Field changes

| Field | Before | After | Touched in |
|-------|--------|-------|------------|
| package.json version | 1.0.37 | 1.0.38 | C77 |
| package.json fuseCounter | 30 | 31 | C77 |
| package.json buildId | 20260517.1 | 20260520.1 | C77 |
| frontend/package.json version | 1.0.37 | 1.0.38 | C78 |
| packages/analyst-client/package.json version | 1.0.37 | 1.0.38 | C79 |
| packages/global-dashboard/package.json version | 1.0.37 | 1.0.38 | C80 |
| packages/global-dashboard-server/package.json version | 1.0.37 | 1.0.38 | C81 |
| README.md line 3 Version label | v1.0.37 | v1.0.38 | C82 |
| README.md line 4 E-fuse counter | 30 | 31 | C82 |
| README.md line 24 Releases-page link | v1.0.37 | v1.0.38 | C82 |

## What R3l ships in v1.0.38

Four full workstreams across the prior R3l PRs (already merged):

  Workstream 1   v100 audit + frontend wiring + curated training library
                 - canonical signals/me, impacts/me, training-recommendations/me endpoints
                 - AC My Signals, Training, Skills tabs wired to canonical
                 - MC SLA, Handoffs tabs wired to canonical
                 - Curated training library (150+ verified URLs across 6 platforms,
                   read-only at runtime, AGPL-fork-and-rebase workflow)
                 - Canonical CPU% + connected-clients endpoints replacing system-health.js
                 - Tier-3 privacy invariant structurally enforced

  Workstream 2a  SOC-grade forensics export package generator
                 - 8 format serializers: Sleuth Kit bodyfile, JSON Lines, Plaso CSV,
                   CEF, EVTX-XML, STIX 2.1, DFXML, CSV
                 - Append-only hash-chained operation log with Ed25519 signing
                 - MC + GD parity (CISO can run forensics against the GD audit log)
                 - admin/ciso separate-actor segregation for delete

  Workstream 2b  Legal hold export package generator
                 - 8 format serializers: EDRM-XML, EML/MIME, PST, Concordance,
                   Relativity, JSON tarball, PDF/Bates, TIFF/Bates
                 - Append-only hash-chained chain-of-custody log
                 - SQL CHECK + application-layer separate-actor enforcement on release
                 - MC + GD parity

  Workstream 3   Scheduler-to-full-suite + real incremental/differential backups +
                 per-schedule destination subset
                 - Real incremental + differential backups (INCR-v1 binary frames format)
                 - Chain-aware restore with per-page SHA-256 integrity verification
                 - Configurable chain-depth limit (system_meta global + per-schedule override)
                 - Six well-defined escalation reasons surfaced in audit + API response
                 - Per-schedule destination subset via tag-based filtering
                 - Three new endpoints: POST /api/backup?strategy=, GET /:id/chain,
                   POST /api/restore/execute-chain/:id

## Supporting work merged during R3l

Not part of the canonical R3l plan but required to ship cleanly:

  - Dockerfile base image bumped from node:20-alpine to node:24-alpine
    (Node 20 went EOL April 2026; required to support better-sqlite3 12.10.0's
    prebuild lineup which dropped Node 20)

  - Rate-limiting hardening pass:
      - Explicit IPv6 /64 keyGenerator on both MC and GD apiLimiters
        (decouples bucketing from express-rate-limit's internal IPv6 logic)
      - TRUST_PROXY env-gated app.set on both servers (so req.ip
        resolves to actual client IP behind reverse proxies)
      - MC/GD apiLimiter parity (standardHeaders 'draft-7',
        legacyHeaders false, validate true, respective health-endpoint skips)
      - .env.example documentation for TRUST_PROXY per topology

  - Five Dependabot dependency bumps merged in sequence:
      electron 42.0.1 -> 42.1.0 (dev)
      ws 8.20.0 -> 8.20.1 (security fix: uninitialized memory disclosure)
      better-sqlite3 12.9.0 -> 12.10.0 (rebased after Node 24 bump)
      express-rate-limit 8.5.1 -> 8.5.2 (rebased after hardening pass)
      @aws-sdk/client-s3 3.1045.0 -> 3.1049.0

## Exit criteria check (from R3L-DETAILED-BUILD-PLAN-v3.md)

  - [x] 82 logical commits shipped across the R3l branches
  - [x] All 5 package.json files at 1.0.38
  - [x] fuseCounter at 31
  - [x] buildId at 20260520.1
  - [x] README header trio + Releases link at v1.0.38
  - [x] All 4 workstream-end audits passed (validated at each merge)
  - [x] Curated training library has 150+ verified URLs across 6 platforms
  - [x] 8 forensic formats produce valid output
  - [x] 8 legal hold formats produce valid output
  - [x] Real incremental/differential backups with page-level integrity verification
  - [x] Per-schedule destination subset works
  - [x] Chain-depth limit enforced
  - [x] Tier-3 privacy invariant structurally enforced
  - [x] Separate-actor enforcement on legal-hold release works at SQL + app layer
  - [x] No POST/PUT/DELETE on training_modules anywhere in codebase

## Next operator step after merge

  1. Pull updated main locally
  2. Tag the release: git tag v1.0.38 && git push origin v1.0.38
  3. The tag push triggers .github/workflows/build.yml, which builds
     installers for macOS (.dmg + .zip), Windows (.exe), and Linux
     (.AppImage) and attaches them to the GitHub Release at the URL
     in README line 24
  4. Verify the build workflow runs green; if so, R3l v1.0.38 is
     officially shipped to the public

After v1.0.38 ships, R3m can begin its delete-pass on the v100 stub routes and the orphaned service classes (assessment-service.js, backup-service.js, compliance-scanner.js, notification-service.js) verified during R3l to have full canonical coverage. system-health.js becomes a delete-candidate now that R3l's C8/C9 canonical equivalents are in place.
