### PR TITLE
Phase U3: drop deprecated certificateSubjectName from AC build.win

### DIFF
--- a/packages/analyst-client/package.json
+++ b/packages/analyst-client/package.json
@@ -63,7 +63,6 @@
           ]
         }
       ],
-      "certificateSubjectName": "FireAlive",
       "icon": "assets/icon.png"
     },
     "linux": {


### PR DESCRIPTION
The Linux installer build in CI failed against the PR K merge commit because electron-builder 26.8.1's config-schema validation rejects an unknown property `certificateSubjectName` on the top-level `build.win` object. electron-builder removed this property from the top-level Windows config in the 25.x line (it lives under `signtoolOptions` now when needed). The validation runs over the entire `build` config regardless of which platform target is selected, so the `electron-builder --linux` invocation in the build-linux job tripped on this Windows-only property despite never using it.

The Analyst Client (packages/analyst-client/) was the only manifest in the repository that declared `certificateSubjectName`. The property was a no-op leftover from an earlier era and was not being used for actual Windows code signing -- FireAlive's current builds are unsigned developer builds across all four desktop apps (no mac.identity, no mac.notarize, no win.cscLink, no win.signtoolOptions configured in any manifest). Removing the property restores electron-builder 26 schema validity without removing any functional capability.

If/when Windows code signing is added to FireAlive's release pipeline, that work will land in a separate PR and will configure the modern `build.win.signtoolOptions` shape (with `certificateSubjectName` as a nested property inside that object, alongside the necessary CI cert- store and password handling).

Validated offline: file parses as JSON; `build.win` now contains only the valid properties `target` and `icon`; `build.mac` and `build.linux` configs are byte-identical to before the edit; a repository-wide grep confirms no other manifest carries deprecated Windows-signing properties (`certificateSubjectName`, `certificateSha1`, `certificateFile`, `certificatePassword`).

Root cause: Phase 0 audit of PR K (build plan §1d) checked for the better-known electron-builder 25+ breakages (mac.identity, mac.notarize, win.cscLink) but did not enumerate the full list of Windows-signing properties that were moved into signtoolOptions.

This commit unblocks the build-linux job and the v1.0.45 release tag can be cut from main once this hotfix is merged and CI reports green.

Phase U3 PR L, commit 1 of 1. Targets v1.0.45 release.