### PR TITLE
Phase B5d1: align pdfkit to ^0.19.0 across app manifests (v1.0.56)

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -13,7 +13,7 @@
   },
   "dependencies": {
     "@signalapp/libsignal-client": "^0.94.0",
-    "pdfkit": "^0.18.0"
+    "pdfkit": "^0.19.0"
   },
   "devDependencies": {
     "react": "18.2.0",

--- a/packages/analyst-client/package.json
+++ b/packages/analyst-client/package.json
@@ -15,7 +15,7 @@
   "dependencies": {
     "@signalapp/libsignal-client": "^0.94.0",
     "node-llama-cpp": "^3.18.1",
-    "pdfkit": "^0.18.0"
+    "pdfkit": "^0.19.0"
   },
   "devDependencies": {
     "react": "18.2.0",

--- a/packages/global-dashboard-server/package.json
+++ b/packages/global-dashboard-server/package.json
@@ -20,6 +20,6 @@
     "dotenv": "^16.3.1",
     "express-rate-limit": "^8.5.0",
     "docx": "^9.7.1",
-    "pdfkit": "^0.18.0"
+    "pdfkit": "^0.19.0"
   }
 }


### PR DESCRIPTION
## Summary

Brings the pdfkit dependency range to `^0.19.0` in the three secondary package manifests so the whole repository declares a single pdfkit version. The root `package.json` and lockfile already moved to pdfkit `^0.19.0`; this aligns the Management Console, Analyst Client, and global dashboard server manifests to match. There is no application version change — this lands under the existing v1.0.56.

## Background

pdfkit was advanced from 0.18.0 to 0.19.0 at the repository root (manifest range and lockfile). pdfkit is pre-1.0, where a caret range locks to the minor, so `^0.18.0` excludes 0.19.0. The three secondary manifests still declared `^0.18.0`, and each runs its own `npm install` during the build — which would have held those components on 0.18.x while the root and the regional server moved to 0.19.x. This removes the split so every component resolves the same pdfkit major.minor.

0.19.0's only breaking changes are a Node 20+ runtime minimum and a raised browser-build minimum. The build runs on Node 22, and pdfkit is used server-side / in main-process code only, so the browser-build minimum does not apply. The remaining 0.19.0 changes are additive options and bug fixes that do not alter the API these components call.

## What this PR changes

- `frontend/package.json` — pdfkit `^0.18.0` -> `^0.19.0` (Management Console)
- `packages/analyst-client/package.json` — pdfkit `^0.18.0` -> `^0.19.0` (Analyst Client)
- `packages/global-dashboard-server/package.json` — pdfkit `^0.18.0` -> `^0.19.0` (the one secondary component that actually generates PDFs)

## What this PR keeps

- All version fields stay at 1.0.56; fuseCounter stays 49; buildId stays 20260608.1. This is a manifest-consistency change only.
- The root `package.json` and lockfile are untouched here — they already carry pdfkit `^0.19.0` / 0.19.0.
- Manifests that do not declare pdfkit (abuse review console, the global dashboard Electron app) are unchanged.

## Commits

1. bump pdfkit to ^0.19.0 in management console
2. bump pdfkit to ^0.19.0 in analyst client
3. bump pdfkit to ^0.19.0 in global dashboard server

## Version and build

No change. Lands under v1.0.56 (fuse counter 49, build 20260608.1).