### PR TITLE
Phase B5d2: run config-lock coverage guard on push and PR

### DIFF
--- a/.github/workflows/config-lock-coverage.yml
+++ b/.github/workflows/config-lock-coverage.yml
@@ -1,0 +1,23 @@
+name: Config-Lock Coverage
+
+# Runs the config-lock coverage guard on every push and pull request. The guard
+# is fast and dependency-free (Node builtins only), so it does not install
+# packages or build anything -- it just verifies that every config-write
+# endpoint is gated by the lock. This is separate from the tag-triggered
+# Build & Release workflow so contributors get coverage feedback on each commit.
+
+on: [push, pull_request]
+
+permissions:
+  contents: read
+
+jobs:
+  config-lock-coverage:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
+        with:
+          node-version: '22'
+      - name: Verify config-lock registry coverage
+        run: node scripts/check-config-lock-coverage.js


### PR DESCRIPTION
New lightweight workflow that runs the config-lock coverage guard on every push and pull request. It installs nothing and builds nothing (the guard uses only Node builtins), so it gives fast per-commit feedback that all config-write endpoints remain gated. Kept separate from the tag-triggered Build & Release workflow.

Re-added directly to main: this file was part of the B5d2 work but did not land in the merge.

Phase B5d2, commit 14.