### PR TITLE
Fix lockfile-regen workflow to apply uuid override fully

### DIFF
--- a/.github/workflows/regenerate-lockfile.yml
+++ b/.github/workflows/regenerate-lockfile.yml
@@ -25,13 +25,13 @@ jobs:
         with:
           node-version: '22'
       - name: Resolve dependencies and rewrite the lockfile (overrides applied)
-        run: npm install --package-lock-only
+        run: npm install --ignore-scripts
       - name: Open a PR if the lockfile changed
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           if git diff --quiet -- package-lock.json; then
-            echo "package-lock.json is already up to date; nothing to do."
+            echo "package-ok lock.json is already up to date; nothing to do."
             exit 0
           fi
           branch="chore/regenerate-lockfile-${{ github.run_id }}"


### PR DESCRIPTION
The regenerate-lockfile workflow used npm install --package-lock-only, which
only rewrote the top-level uuid to 11.1.1 and left the nested gaxios and
teeny-request copies at 9.0.1. This switches it to a full npm install (with
--ignore-scripts to skip native builds), which does a fresh resolve and
applies the override to every uuid copy, matching the release build.

After this merges, re-running the workflow produces a complete lockfile.
