### PR TITLE
remove unused sharp dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,7 +54,6 @@
     "nodemailer": "^8.0.10",
     "pdfkit": "^0.19.0",
     "qrcode": "^1.5.4",
-    "sharp": "^0.34.5",
     "ssh2": "^1.15.0",
     "tweetnacl": "^1.0.3",
     "tweetnacl-util": "^0.15.1",


### PR DESCRIPTION
Remove the `sharp` image-processing dependency from the root manifest. It is a direct production dependency with zero usage anywhere in the codebase (no require/import sites, no script references) and is tied to no planned feature, so it only adds a native libvips binary to every install plus recurring dependency-update churn. Removing it also moots Dependabot #240 (the sharp 0.34.5 -> 0.35.1 bump), whose 0.35 breaking changes were never relevant because nothing loads sharp.

Changed (package.json):
- remove sharp from dependencies