### PR TITLE
chore: upgrade react and react-dom to 19 across all four apps

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -16,8 +16,8 @@
     "pdfkit": "^0.19.0"
   },
   "devDependencies": {
-    "react": "18.2.0",
-    "react-dom": "18.2.0",
+    "react": "19.2.7",
+    "react-dom": "19.2.7",
     "esbuild": "0.28.1",
     "electron": "^42.4.0",
     "electron-builder": "^26.8.1"

--- a/packages/abuse-review-console/package.json
+++ b/packages/abuse-review-console/package.json
@@ -12,8 +12,8 @@
     "build:linux": "electron-builder --linux"
   },
   "devDependencies": {
-    "react": "18.2.0",
-    "react-dom": "18.2.0",
+    "react": "19.2.7",
+    "react-dom": "19.2.7",
     "esbuild": "0.28.1",
     "electron": "^42.4.0",
     "electron-builder": "^26.8.1"

--- a/packages/analyst-client/package.json
+++ b/packages/analyst-client/package.json
@@ -18,8 +18,8 @@
     "pdfkit": "^0.19.0"
   },
   "devDependencies": {
-    "react": "18.2.0",
-    "react-dom": "18.2.0",
+    "react": "19.2.7",
+    "react-dom": "19.2.7",
     "esbuild": "0.28.1",
     "electron": "^42.4.0",
     "electron-builder": "^26.8.1"

--- a/packages/global-dashboard/package.json
+++ b/packages/global-dashboard/package.json
@@ -12,8 +12,8 @@
     "build:linux": "electron-builder --linux"
   },
   "devDependencies": {
-    "react": "18.2.0",
-    "react-dom": "18.2.0",
+    "react": "19.2.7",
+    "react-dom": "19.2.7",
     "esbuild": "0.28.1",
     "electron": "^42.4.0",
     "electron-builder": "^26.8.1"


### PR DESCRIPTION
## Summary

Upgrades `react` and `react-dom` from 18.2.0 to 19.2.7 across all four
Electron app UIs (Management Console, Analyst Client, Global Dashboard,
Abuse Review Console). This is a version-bump-only change: a full audit
of every app found zero React 19 breaking-change exposure, so no UI code
and no build configuration changed. Post-B5g housekeeping; no version,
fuse, or buildId bump.

## Background

Dependabot's new multi-manifest coverage opened React 18->19 update PRs,
but split across `react` and `react-dom` per app. Merging a
`react-dom`-only PR would have left `react` at 18.2.0 against `react-dom`
19.2.7 -- a major mismatch (react-dom 19 hard-requires react 19) that
bundles without error under esbuild but crashes at render. Bumping both
together here resolves that correctly and lets the individual Dependabot
React PRs auto-close once `main` reaches 19.2.7.

## What this PR changes

- `frontend/package.json` -- react + react-dom 18.2.0 -> 19.2.7
- `packages/analyst-client/package.json` -- react + react-dom -> 19.2.7
- `packages/global-dashboard/package.json` -- react + react-dom -> 19.2.7
- `packages/abuse-review-console/package.json` -- react + react-dom ->
  19.2.7

## React 19 compatibility audit

All four UIs were scanned against React 19's breaking changes before
bumping. Every check came back clean:

- All four mount via `createRoot` from `react-dom/client` (retained in
  19); none use the removed `ReactDOM.render` / `hydrate` /
  `unmountComponentAtNode`.
- No removed legacy APIs anywhere: no `findDOMNode`, `createFactory`,
  `defaultProps`/`propTypes`, legacy context, string refs, `createClass`.
- Hook usage is minimal and stable in 19 (`useState`/`useEffect`/
  `useRef` only); no `forwardRef`/`createRef`, no renamed hooks, no
  context.
- No other React-coupled libraries in any manifest, so no
  peer-dependency conflicts.
- The build uses esbuild `--jsx=automatic`, which compiles to
  `react/jsx-runtime` -- shipped unchanged in React 19 -- so the build
  configuration needs no change.

Because nothing of ours touches a changed or removed surface, the
migration is a dependency bump with no accompanying code.

## What this PR keeps

- No UI code changes and no build-config changes -- the four `.jsx`
  sources and the esbuild invocations are untouched.
- No version, fuse, or buildId bump -- rides into the not-yet-tagged
  v1.0.62 release with the rest of the post-B5g cleanup.

## Validation

CI builds all four installers (`esbuild` + `electron-builder`) against
react@19 when the v1.0.62 tag is cut, so a build-level regression
surfaces before release. CI does not launch the apps, so React 19
runtime behavior is not exercised automatically; given zero code changes
and zero removed-API usage that residual risk is low, and a single
launch of any built installer post-tag would confirm it.

## Commits

1. bump mc react and react-dom to 19.2.7
2. bump analyst-client react and react-dom to 19.2.7
3. bump global-dashboard react and react-dom to 19.2.7
4. bump abuse-review-console react and react-dom to 19.2.7

## No version change

Housekeeping -- no version, fuseCounter, or buildId change. The next tag
is v1.0.62 (already set on main by B5g).