### PR TITLE
chore: align app electron-builder floors to ^26.15.3

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -20,7 +20,8 @@
     "react-dom": "19.2.7",
     "esbuild": "0.28.1",
     "electron": "^42.4.0",
-    "electron-builder": "^26.8.1"
+    "electron-builder": "^26.15.3"
+
   },
   "build": {
     "appId": "com.firealive.management-console",

--- a/packages/abuse-review-console/package.json
+++ b/packages/abuse-review-console/package.json
@@ -16,7 +16,7 @@
     "react-dom": "19.2.7",
     "esbuild": "0.28.1",
     "electron": "^42.4.0",
-    "electron-builder": "^26.8.1"
+    "electron-builder": "^26.15.3"
   },
   "build": {
     "appId": "com.firealive.abuse-review-console",

--- a/packages/analyst-client/package.json
+++ b/packages/analyst-client/package.json
@@ -22,7 +22,7 @@
     "react-dom": "19.2.7",
     "esbuild": "0.28.1",
     "electron": "^42.4.0",
-    "electron-builder": "^26.8.1"
+    "electron-builder": "^26.15.3"
   },
   "build": {
     "appId": "com.firealive.analyst-client",

--- a/packages/global-dashboard/package.json
+++ b/packages/global-dashboard/package.json
@@ -16,7 +16,7 @@
     "react-dom": "19.2.7",
     "esbuild": "0.28.1",
     "electron": "^42.4.0",
-    "electron-builder": "^26.8.1"
+    "electron-builder": "^26.15.3"
   },
   "build": {
     "appId": "com.firealive.global-dashboard",


### PR DESCRIPTION
## Summary

Aligns the declared electron-builder floor in the four Electron app
manifests from `^26.8.1` to `^26.15.3`, matching the root manifest
(bumped via Dependabot #251). All five manifests now state the same
floor. Build-time devDependency only; no runtime impact, no version
bump.

## Background

Dependabot opened a single electron-builder bump (#251) for the root
manifest, because only root carries a committed `package-lock.json`
pinning an older resolved version. The four app manifests declare
`electron-builder: ^26.8.1`, and that caret already resolves to 26.15.3
at install time, so Dependabot saw no drift to report for them. This PR
makes the floor explicit across the apps so all five manifests agree, in
keeping with the manifest-consistency goal of this cleanup.

## What this PR changes

- `frontend/package.json` -- electron-builder ^26.8.1 -> ^26.15.3
- `packages/analyst-client/package.json` -- electron-builder -> ^26.15.3
- `packages/global-dashboard/package.json` -- electron-builder -> ^26.15.3
- `packages/abuse-review-console/package.json` -- electron-builder ->
  ^26.15.3

## Relationship to #251

#251 bumps the root manifest (package.json + package-lock.json) and is
merged separately. This PR covers only the four app manifests, which
have no lockfiles. Together they bring every manifest to
electron-builder ^26.15.3.

## Validation

No functional change: the `^26.8.1` caret already resolved to 26.15.3 at
build time, so CI was already packaging with 26.15.3. This only raises
the declared minimum. electron-builder is a build-time devDependency and
does not ship in any app; CI's installer build at the v1.0.62 tag
exercises it.

## Commits

1. align mc electron-builder to ^26.15.3
2. align analyst-client electron-builder to ^26.15.3
3. align global-dashboard electron-builder to ^26.15.3
4. align abuse-review-console electron-builder to ^26.15.3

## No version change

Housekeeping -- no version, fuseCounter, or buildId change. Rides into
the not-yet-tagged v1.0.62 release.