### PR TITLE
override transitive protobufjs to ^7.6.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,8 @@
   },
   "homepage": "https://github.com/petermancina/firealive#readme",
   "overrides": {
-    "uuid": "^11.1.1"
+    "uuid": "^11.1.1",
+    "protobufjs": "^7.6.3"
   },
   "dependencies": {
     "@aws-sdk/client-kms": "^3.1064.0",


### PR DESCRIPTION
Add a scoped npm override forcing the transitive protobufjs (pulled by @google-cloud/kms and @google-cloud/storage via google-gax) up to ^7.6.3. This remediates two Dependabot advisories on protobufjs <= 7.6.2 -- schema-name shadowing and unbounded Any expansion -- both denial-of-service class and both fixed in 7.6.3. FireAlive does not use protobufjs directly and only loads trusted Google API schemas, so practical exposure is negligible; the override clears the alerts.

Caret-bounded (^7.6.3) to match the existing uuid override and stay within protobufjs 7.x, which google-gax expects.

Changed (package.json):
- overrides.protobufjs: added at ^7.6.3