### PR TITLE
Remove ReDoS-flagged base64 padding regex (CodeQL js/polynomial-redos)

### DIFF
--- a/packages/global-dashboard-server/services/gd-hardware-keystore-macos.js
+++ b/packages/global-dashboard-server/services/gd-hardware-keystore-macos.js
@@ -183,7 +183,7 @@ function realRunHelper(args) {
 }
 
 function toBase64Url(buf) {
-  return buf.toString('base64').split('+').join('-').split('/').join('_').replace(/=+$/, '');
+  return buf.toString('base64url');
 }
 
 function x963ToSpkiDer(b64point) {

--- a/packages/shared/hardware-key-macos.js
+++ b/packages/shared/hardware-key-macos.js
@@ -168,7 +168,7 @@ function realRunHelper(args) {
 }
 
 function toBase64Url(buf) {
-  return buf.toString('base64').split('+').join('-').split('/').join('_').replace(/=+$/, '');
+  return buf.toString('base64url');
 }
 
 function x963ToSpkiDer(b64point) {

--- a/packages/shared/hardware-wrap-macos.js
+++ b/packages/shared/hardware-wrap-macos.js
@@ -180,7 +180,7 @@ function realRunHelper(args) {
 }
 
 function toBase64Url(buf) {
-  return buf.toString('base64').split('+').join('-').split('/').join('_').replace(/=+$/, '');
+  return buf.toString('base64url');
 }
 
 function leftPad32(buf) {

--- a/server/services/external-restore/sftp.js
+++ b/server/services/external-restore/sftp.js
@@ -232,7 +232,7 @@ function withSftp(creds, log, op) {
     // Host key verification -- REQUIRED PINNING (see file header).
     config.hostVerifier = (key) => {
       const hash = crypto.createHash('sha256').update(key).digest('base64')
-        .replace(/=+$/, '');  // SSH fingerprint convention strips trailing '='
+        .replaceAll('=', '');  // SSH fingerprint convention strips trailing '='
       const fingerprint = `SHA256:${hash}`;
       if (creds.hostKeyFingerprint !== fingerprint) {
         log('error', 'sftp host key MISMATCH -- refusing connection', {

--- a/server/services/instance-anchor/hardware-keystore-macos.js
+++ b/server/services/instance-anchor/hardware-keystore-macos.js
@@ -176,7 +176,7 @@ function realRunHelper(args) {
 }
 
 function toBase64Url(buf) {
-  return buf.toString('base64').split('+').join('-').split('/').join('_').replace(/=+$/, '');
+  return buf.toString('base64url');
 }
 
 function x963ToSpkiDer(b64point) {


### PR DESCRIPTION
CodeQL (js/polynomial-redos) flagged the `/=+$/` regular expression used to strip base64 padding in the macOS hardware-keystore base64url helper, treating it as a polynomial-ReDoS sink on library input.

Real-world exploitability is negligible: the regex only ever runs on the output of `Buffer.toString('base64')`, which has at most two trailing `=` (never a long run), so the quadratic worst case cannot be reached. This PR removes the flagged pattern anyway, for a clean alert board and to keep these paths regex-free.

Changes:
- The four copies of the `toBase64Url` helper (shared hardware-wrap, shared hardware-key, instance-anchor keystore, and the GD keystore) now use Node's native `buf.toString('base64url')`, which produces identical unpadded URL-safe base64 with no regular expression. Unpadded base64url is also the correct encoding for the JWK x/y coordinates these build.
- The SFTP host-key verifier strips the trailing padding from its SHA256 fingerprint with `String.replaceAll('=', '')` instead. The SSH fingerprint must keep the standard base64 alphabet, so base64url is not used there.

All five changes are behavior-preserving (byte-identical output); there is no functional change. This resolves the open alert plus the three sibling copies of the same helper that CodeQL would otherwise flag on the next scan.