### PR TITLE
chore: raise regression Node floor to >=20 (undici 7)

### DIFF
--- a/server/services/regression-runner.js
+++ b/server/services/regression-runner.js
@@ -910,10 +910,10 @@ class RegressionRunner {
     });
 
     // ── Category 12: System ────────────────────────────────────────
-    await check('system', 'Node.js version >= 18', () => {
+    await check('system', 'Node.js version >= 20', () => {
       const major = parseInt(process.version.replace(/^v/, '').split('.')[0], 10);
-      if (!Number.isFinite(major) || major < 18) {
-        throw new Error('Node ' + process.version + ' is below the supported floor (>=18)');
+      if (!Number.isFinite(major) || major < 20) {
+        throw new Error('Node ' + process.version + ' is below the supported floor (>=20)');
       }
       return 'Node ' + process.version;
     });


### PR DESCRIPTION
Undici 7 (merged for its security fixes) dropped Node 18 support and requires Node 20+, so the supported runtime floor is now Node 20. Raise the regression runner's Node-version check from >=18 to >=20 across the assertion name, the comparison, and the error message. CI already runs Node 22.