### PR TITLE
build(deps): bump shared libsignal-client to 0.97.2 to match apps

### DIFF
--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -24,7 +24,7 @@
     "./package.json": "./package.json"
   },
   "dependencies": {
-    "@signalapp/libsignal-client": "^0.96.1",
+    "@signalapp/libsignal-client": "^0.97.2",
     "pdfkit": "^0.19.0"
   }
 }


### PR DESCRIPTION
Pairs with #390 (frontend) and #391 (analyst-client), which bump @signalapp/libsignal-client to 0.97.2. packages/shared carries the same dependency at ^0.96.1 but Dependabot opened no PR for it; because ^0.96.1 is a 0.x caret it will not resolve 0.97.2, so leaving it would split the Signal Protocol E2EE library between the shared code and the app code that must interoperate. This aligns all three copies at 0.97.2. Peer-messaging and prekey flows should be smoke-tested after the coordinated bump (crypto-critical, pre-1.0 minor).